### PR TITLE
LPS-171284 Test fix for ObjectRelationships#CannotRelateAnEntryWithItself

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -234,6 +234,8 @@ definition {
 	macro assertRelationshipNotPresent {
 		LexiconEntry.gotoAdd();
 
+		MenuItem.clickNoError(menuItem = "Select Existing One");
+
 		SelectFrame(locator1 = "IFrame#MODAL_BODY");
 
 		AssertTextEquals(


### PR DESCRIPTION
**Ticket:**
[LRQA-171284](https://issues.liferay.com/browse/LPS-171284)

**Failure:**
`
java.lang.Exception: Element is not present at "//div[contains(@class,'modal-body')]//iframe" /opt/dev/projects/github/liferay-portal/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro[assertRelationshipNotPresent]:237 /opt/dev/projects/github/liferay-portal/modules/apps/object/object-test/src/testFunctional/tests/ObjectRelationships.testcase[CannotRelateAnEntryWithItself]:1218
`
