### PR TITLE
LPS-169212 Test Fix

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -333,6 +333,8 @@ definition {
 
 		Button.clickSave();
 
+		Alert.viewSuccessMessage();
+
 		WaitForSPARefresh();
 	}
 
@@ -925,6 +927,8 @@ definition {
 			value1 = "${newEntryValue}");
 
 		Button.clickSave();
+
+		Alert.viewSuccessMessage();
 	}
 
 	macro editObjectAction {

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectPortlet.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectPortlet.macro
@@ -307,6 +307,8 @@ definition {
 		Button.clickSave();
 
 		WaitForSPARefresh();
+
+		Navigator.gotoBack();
 	}
 
 	macro deleteEntry {

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectPortlet.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectPortlet.macro
@@ -276,6 +276,12 @@ definition {
 		Click(
 			key_picklistOption = "${entryOption}",
 			locator1 = "ObjectAdmin#ENTRY_PICKLIST_OPTION");
+
+		if (IsElementPresent(key_feedbackMessage = "The field value is invalid.", locator1 = "Form#FEEDBACK_MESSAGE")) {
+			WaitForElementNotPresent(
+				key_feedbackMessage = "The field value is invalid.",
+				locator1 = "Form#FEEDBACK_MESSAGE");
+		}
 	}
 
 	macro chooseEntryOnRelationshipFieldSpecific {
@@ -291,6 +297,12 @@ definition {
 		Click(
 			key_picklistOption = "${entryOption}",
 			locator1 = "ObjectAdmin#ENTRY_PICKLIST_OPTION");
+
+		if (IsElementPresent(key_feedbackMessage = "The field value is invalid.", locator1 = "Form#FEEDBACK_MESSAGE")) {
+			WaitForElementNotPresent(
+				key_feedbackMessage = "The field value is invalid.",
+				locator1 = "Form#FEEDBACK_MESSAGE");
+		}
 
 		Button.clickSave();
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -3475,6 +3475,8 @@ definition {
 
 		Button.clickSubmitForPublication();
 
+		Alert.viewSuccessMessage();
+
 		Navigator.openURL();
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject85");

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectForms.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectForms.testcase
@@ -213,6 +213,8 @@ definition {
 
 		Button.clickSubmitForPublication();
 
+		Alert.viewSuccessMessage();
+
 		Navigator.openURL();
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject209");
@@ -261,6 +263,8 @@ definition {
 			fieldValue = "By building a vibrant business, making technology useful, and investing in communities, we make it possible for people to reach their full potential to serve others.");
 
 		Button.clickSubmitForPublication();
+
+		Alert.viewSuccessMessage();
 
 		Navigator.openURL();
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectsPopulating.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectsPopulating.testcase
@@ -91,6 +91,8 @@ definition {
 
 		Button.clickSubmitForPublication();
 
+		Alert.viewSuccessMessage();
+
 		Navigator.openURL();
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject214");
@@ -150,6 +152,8 @@ definition {
 
 		Button.clickSubmitForPublication();
 
+		Alert.viewSuccessMessage();
+
 		Navigator.openURL();
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject215");
@@ -203,6 +207,8 @@ definition {
 
 		Button.clickSubmitForPublication();
 
+		Alert.viewSuccessMessage();
+
 		Navigator.openURL();
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject216");
@@ -255,6 +261,8 @@ definition {
 			fieldValue = "01/01/2001");
 
 		Button.clickSubmitForPublication();
+
+		Alert.viewSuccessMessage();
 
 		Navigator.openURL();
 
@@ -313,6 +321,8 @@ definition {
 
 		Button.clickSubmitForPublication();
 
+		Alert.viewSuccessMessage();
+
 		Navigator.openURL();
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject218");
@@ -366,6 +376,8 @@ definition {
 
 		Button.clickSubmitForPublication();
 
+		Alert.viewSuccessMessage();
+
 		Navigator.openURL();
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject219");
@@ -418,6 +430,8 @@ definition {
 			fieldValue = "1234567891234567");
 
 		Button.clickSubmitForPublication();
+
+		Alert.viewSuccessMessage();
 
 		Navigator.openURL();
 
@@ -486,6 +500,8 @@ definition {
 
 		Button.clickSubmitForPublication();
 
+		Alert.viewSuccessMessage();
+
 		Navigator.openURL();
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject221");
@@ -540,6 +556,8 @@ definition {
 			fieldValue = "Test Text Test Text Test Text Test Text Test Text Test Text Test Text  Test");
 
 		Button.clickSubmitForPublication();
+
+		Alert.viewSuccessMessage();
 
 		Alert.viewSuccessMessage();
 
@@ -618,6 +636,8 @@ definition {
 
 		Button.clickSubmitForPublication();
 
+		Alert.viewSuccessMessage();
+
 		Navigator.openURL();
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject223");
@@ -670,6 +690,8 @@ definition {
 			fieldValue = "Test text");
 
 		Button.clickSubmitForPublication();
+
+		Alert.viewSuccessMessage();
 
 		Navigator.openURL();
 
@@ -727,6 +749,8 @@ definition {
 			fieldValue = "01/01/2001");
 
 		Button.clickSubmitForPublication();
+
+		Alert.viewSuccessMessage();
 
 		Navigator.openURL();
 


### PR DESCRIPTION
**Ticket:**
[LRQA-169212](https://issues.liferay.com/browse/LPS-169212)

**Failure:**
`
java.lang.Exception: Element is not present at "//div[contains(@class,'dnd-tbody')]//*[contains(text(),'Public Account')]" /opt/dev/projects/github/liferay-portal/modules/apps/object/object-test/src/testFunctional/macros/ObjectPortlet.macro[viewEntry]:448 /opt/dev/projects/github/liferay-portal/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase[CanOnlySeeEntriesFromAccount]:2733
`

**Tests Failing:**
- LocalFile.CreateObject#CanOnlySeeEntriesFromAccount 
- LocalFile.CreateObject#CanSubmitEntriesOnFormWhenReactivated 
- LocalFile.ObjectCustomValidation#CanValidateGroovyAction 
- LocalFile.ObjectCustomViews#CanView2RelationshipFieldValues 
- LocalFile.ObjectForms#CanMapClobTypeAndViewEntriesMultipleLines 
- LocalFile.ObjectForms#CanMapClobTypeAndViewEntriesSingleLine 
- LocalFile.ObjectPermission#CanEditItsOwnEntryWithOnlyAddPermission 
- LocalFile.ObjectsPopulating#CanMapAndViewEntriesForFieldGroup 
- LocalFile.ObjectsPopulating#CanMapBigDecimalTypeAndViewEntries 
- LocalFile.ObjectsPopulating#CanMapBooleanTypeAndViewEntries 
- LocalFile.ObjectsPopulating#CanMapDateTypeAndViewEntries 
- LocalFile.ObjectsPopulating#CanMapDoubleTypeAndViewEntries 
- LocalFile.ObjectsPopulating#CanMapIntegerTypeAndViewEntries 
- LocalFile.ObjectsPopulating#CanMapLongTypeAndViewEntries 
- LocalFile.ObjectsPopulating#CanMapPicklistTypeAndViewEntries 
- LocalFile.ObjectsPopulating#CanSubmitEntryWithDoubleFieldBlank 
- LocalFile.ObjectsPopulating#EntriesAreNotDeletedWhenFormIsDeleted 
- LocalFile.ObjectsPopulating#FieldWithCapitalizedLetters 
- LocalFile.SystemObjectAccount#CanCreateActionOnSystemAccount