### PR TITLE
LPS-172307 Test fix for DMSmoke#DeleteDocumentWithFieldsFromCustomDocTypeAndMetadataSet

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaMetadataSets.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaMetadataSets.path
@@ -32,7 +32,7 @@
 </tr>
 <tr>
 	<td>METADATA_SETS_NAME</td>
-	<td>//td//a[contains(.,'${key_metadataSetName}')]</td>
+	<td>//tr[@data-qa-id="row"]//td[contains(.,'${key_metadataSetName}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**Ticket:**
[LPS-172307](https://issues.liferay.com/browse/LPS-172307)

**Failure:**
`
java.lang.Exception: Element is not present at "//td//a[contains(.,'DM Metadata Set Name')]" /opt/dev/projects/github/liferay-portal/portal-web/test/functional/com/liferay/portalweb/macros/DMDocumentType.macro[selectPGMetadataSet]:270 /opt/dev/projects/github/liferay-portal/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/documentsadministration/fields/DMSmoke.testcase[DeleteDocumentWithFieldsFromCustomDocTypeAndMetadataSet]:56
`

**Tests Failing:**:
- DMSmoke#DeleteDocumentWithFieldsFromCustomDocTypeAndMetadataSet