### PR TITLE
LPS-172166 Test fix for DynamicdatalistsUsecase#AddListWithoutDataDefinitionAndAssertErrorMessage

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/usecase/DynamicdatalistsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/usecase/DynamicdatalistsUsecase.testcase
@@ -74,11 +74,7 @@ definition {
 
 		Button.clickSave();
 
-		Alert.viewRequestFailedToComplete();
-
-		AssertTextEquals.assertPartialText(
-			locator1 = "Message#ERROR_1",
-			value1 = "Please enter a valid definition.");
+		Alert.viewSpecificRequiredField(fieldFieldLabel = "Data Definition");
 	}
 
 	@description = "This is a use case for LPS-50557."


### PR DESCRIPTION
**Ticket:**
[LPS-172166](https://issues.liferay.com/browse/LPS-172166)

**Failure:**
`
java.lang.Exception: Element is not present at "//div[contains(@class,'alert-danger')][contains(@class,'alert-dismissible')][contains(.,'Your request failed to complete.')]" /opt/dev/projects/github/liferay-portal/portal-web/test/functional/com/liferay/portalweb/macros/Alert.macro[viewRequestFailedToComplete]:112 /opt/dev/projects/github/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/usecase/DynamicdatalistsUsecase.testcase[AddListWithoutDataDefinitionAndAssertErrorMessage]:77
`

**Tests Failing:**:
- DynamicdatalistsUsecase#AddListWithoutDataDefinitionAndAssertErrorMessage