### PR TITLE
LPS-170217 Remove test from quarantine

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldReference.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldReference.testcase
@@ -147,8 +147,6 @@ definition {
 	@description = "This is a test for LRQA-68737. This test verifies that the field reference can not be the same for two fields."
 	@priority = "5"
 	test CanNotBeTheSameForTwoFields {
-		property portal.upstream = "quarantine";
-
 		NavItem.gotoStructures();
 
 		WebContentStructures.addCP(structureName = "WC Structure Title");


### PR DESCRIPTION
**Ticket:**
[LPS-170217](https://issues.liferay.com/browse/LPS-170217)

**Failure:**
`
java.lang.Exception: Expected text "Text71561731" does not match actual text "TextReference" at "//div[contains(@class,'sidebar')]//label[contains(.,'Field Reference')]//following-sibling::input[contains(@class,'form-control') and (@type='text')]" /opt/dev/projects/github/liferay-portal/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DEBuilder.macro[assertFieldReference]:254 /opt/dev/projects/github/liferay-portal/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldReference.testcase[CanNotBeTheSameForTwoFields]:177
`

**Tests Failing:**:
- DEFieldReference#CanNotBeTheSameForTwoFields