### PR TITLE
LPS-173210 Test Fix ObjectCustomLayouts#CanCreateObjectWithCategorizationSection

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1320,7 +1320,7 @@ definition {
 	macro viewCategorizationInObjectEntry {
 		AssertElementPresent(locator1 = "ObjectAdmin#CATEGORIZATION_TITLE_INTO_OBJECT");
 
-		AssertElementPresent(locator1 = "CalendarEditEvent#CATEGORIZATION_TAG_FIELD");
+		AssertElementPresent(locator1 = "AssetCategorization#TAGS_FIELD");
 
 		for (var vocabularyName : list "Topic,Audience,Stage") {
 			AssertElementPresent(

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1318,12 +1318,12 @@ definition {
 	}
 
 	macro viewCategorizationInObjectEntry {
-		AssertElementPresent(locator1 = "ObjectAdmin#CATEGORIZATION_TITLE_INTO_OBJECT");
+		AssertVisible(locator1 = "ObjectAdmin#CATEGORIZATION_TITLE_INTO_OBJECT");
 
-		AssertElementPresent(locator1 = "AssetCategorization#TAGS_FIELD");
+		AssertVisible(locator1 = "AssetCategorization#TAGS_FIELD");
 
 		for (var vocabularyName : list "Topic,Audience,Stage") {
-			AssertElementPresent(
+			AssertVisible(
 				key_vocabularyName = "${vocabularyName}",
 				locator1 = "AssetCategorization#CATEGORIES_FIELD");
 		}


### PR DESCRIPTION
**Ticket:**
[LPS-173210](https://issues.liferay.com/browse/LPS-173210)

**Test:**
ObjectCustomLayouts#CanCreateObjectWithCategorizationSection

**Failure:**
`error message: java.lang.Exception: Element is not present at "//input[contains(@title,'Add Tags')] | //div[contains(@class,'tags-selector')]//input[contains(@class,'form-control-inset')]" /opt/dev/projects/github/liferay-portal/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro[viewCategorizationInObjectEntry]:1305 /opt/dev/projects/github/liferay-portal/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomLayouts.testcase[CanCreateObjectWithCategorizationSection]:367`