### PR TITLE
LPS-173804 Test Fix for changes at field reference

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldReference.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldReference.testcase
@@ -152,9 +152,11 @@ definition {
 			fieldLabel = "First Text",
 			fieldName = "Text");
 
+		var textReference = "TextReference";
+
 		DEBuilder.editFieldReference(
 			fieldLabel = "First Text",
-			fieldReference = "TextReference");
+			fieldReference = "${textReference}");
 
 		DEBuilder.addField(
 			fieldLabel = "Second Text",
@@ -165,15 +167,14 @@ definition {
 		DEBuilder.editFieldReference(
 			assertErrorMessage = "This reference is already being used. Try a different one.",
 			fieldLabel = "Second Text",
-			fieldReference = "TextReference");
+			fieldReference = "${textReference}");
 
-		WebContentStructures.saveCP();
+		Button.click(button = "Save");
 
-		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
-
-		DEBuilder.assertFieldReference(
-			fieldLabel = "Second Text",
-			fieldReference = "${originalFieldReference}");
+		AssertTextEquals.assertPartialText(
+			key_alertMessage = "The definition field name ${textReference} was defined more than once",
+			locator1 = "Message#ERROR_ENTER_A_VALID_VALUE",
+			value1 = "The definition field name ${textReference} was defined more than once");
 	}
 
 	@description = "This is a test for LRQA-68737. This test verifies that field reference can not be the same for two Options of fields."

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldReference.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldReference.testcase
@@ -97,19 +97,16 @@ definition {
 			fieldLabel = "Text",
 			fieldName = "Text");
 
-		var originalFieldReference = DEBuilder.getFieldReference(fieldLabel = "Text");
-
 		DEBuilder.editFieldReference(
 			fieldLabel = "Text",
 			fieldReference = "");
 
-		WebContentStructures.saveCP();
+		Button.click(button = "Save");
 
-		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
-
-		DEBuilder.assertFieldReference(
-			fieldLabel = "Text",
-			fieldReference = "${originalFieldReference}");
+		AssertTextEquals.assertPartialText(
+			key_alertMessage = "Invalid characters were defined for field",
+			locator1 = "Message#ERROR_ENTER_A_VALID_VALUE",
+			value1 = "Invalid characters were defined for field");
 	}
 
 	@description = "This is a test for LRQA-68737. This test verifies that field reference can not be blank for the Options of a field."

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/RichTextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/RichTextField.testcase
@@ -182,10 +182,6 @@ definition {
 	test PublishWebContentWithEmptyRequiredRichText {
 		property portal.acceptance = "false";
 
-		DataEngine.addField(
-			fieldFieldLabel = "Rich Text",
-			fieldName = "Rich Text");
-
 		DataEngine.editFieldRequired(fieldFieldLabel = "Rich Text");
 
 		WebContentStructures.saveCP();


### PR DESCRIPTION
**Ticket:**
[LPS-173804](https://issues.liferay.com/browse/LPS-173804)

**Test:**
- LocalFile.DEFieldReference#CanNotBeTheSameForTwoFields
- LocalFile.DEFieldReference#CanNotBeBlank
- RichTextField#PublishWebContentWithEmptyRequiredRichText

**Failure:**
`java.lang.Exception: Element is not present at "//*[contains(@class,'nav-link') and normalize-space()='Web Content'][not(contains(@id,'ProductMenu') or contains(@href,'site_administration'))]" /opt/dev/projects/github/liferay-portal/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro[gotoNavTab]:116 /opt/dev/projects/github/liferay-portal/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/RichTextField.testcase[PublishWebContentWithEmptyRequiredRichText]:193`