### PR TITLE
LPS-139185 - Refactor CreateObject.macro | Master

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -242,10 +242,6 @@ definition {
 			value1 = "${fieldLabel}");
 	}
 
-	macro assertToggleCollapsibleChecked {
-		AssertChecked.assertCheckedNotVisible(locator1 = "CreateObject#TOGGLE_COLLAPSIBLE");
-	}
-
 	macro assertValuesOnObjectData {
 		var key_fieldType = "form-control";
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -46,12 +46,6 @@ definition {
 			locator1 = "CreateObject#ENTRY_RELATIONSHIP_FIELD_OPTION");
 	}
 
-	macro assertCannotAddRelationshipTabFirst {
-		LexiconEntry.gotoAddNoSelectFrame();
-
-		AssertElementPresent(locator1 = "CreateObject#DISABLED_TAB_TYPE_RELATIONSHIPS");
-	}
-
 	macro assertCustomObject {
 		AssertElementPresent(
 			key_labelName = "${labelName}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -175,12 +175,6 @@ definition {
 			locator1 = "ObjectAdmin#ANY_TAB_ON_ENTRY");
 	}
 
-	macro assertObjectNotPresentInSubmissions {
-		AssertElementNotPresent(
-			key_submissionName = "${objectName}",
-			locator1 = "WorkflowSubmissions#SUBMISSION_BY_NAME");
-	}
-
 	macro assertObjectPluralLabel {
 		AssertTextEquals(
 			locator1 = "CreateObject#OBJECT_PLURAL_LABEL",

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -193,12 +193,6 @@ definition {
 		AssertElementNotPresent(locator1 = "CreateObject#ASSERT_TWO_COLUMN_FIELD_ENTRY");
 	}
 
-	macro assertPanelCategoryKey {
-		AssertTextEquals(
-			locator1 = "CreateObject#PANEL_CATEGORY_KEY",
-			value1 = "${panelCategoryKey}");
-	}
-
 	macro assertRelatedObject {
 		AssertElementPresent(
 			key_relatedObject = "${relatedObject}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -87,10 +87,6 @@ definition {
 		AssertElementPresent(locator1 = "CreateObject#SAVE_BUTTON_DISABLED");
 	}
 
-	macro assertDisabledObjectName {
-		AssertElementPresent(locator1 = "CreateObject#DISABLED_OBJECT_NAME");
-	}
-
 	macro assertEntrySelectedOnRelationshipField {
 		AssertElementPresent(
 			key_entry = "${entry}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -215,12 +215,6 @@ definition {
 			value1 = "No entries were found.");
 	}
 
-	macro assertScopeFieldSelected {
-		AssertTextEquals(
-			locator1 = "ObjectAdmin#SELECT_OBJECT_SCOPE",
-			value1 = "${fieldScope}");
-	}
-
 	macro assertSearchableSectionOptionsAppears {
 		AssertElementPresent(
 			key_radioOption = "${radioOption}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -34,12 +34,6 @@ definition {
 		Alert.viewSuccessMessage();
 	}
 
-	macro assertAccountRestrictedFieldDisabled {
-		AssertElementPresent(
-			key_valueName = "${valueName}",
-			locator1 = "CreateObject#ACCOUNT_RESTRICTED_FIELD_DISABLED");
-	}
-
 	macro assertAddedEntryRelationshipIsDisplayed {
 		LexiconEntry.gotoAdd();
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -420,10 +420,6 @@ definition {
 			locator1 = "CreateObject#VIEW_OBJECT");
 	}
 
-	macro viewToogleAccountRestrictionDisabled {
-		AssertElementPresent(locator1 = "CreateObject#TOGGLE_ACCOUNT_RESTRICTION_DISABLED");
-	}
-
 	macro withdrawObjectTask {
 		Click(
 			key_taskName = "${objectName}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -145,12 +145,6 @@ definition {
 			locator1 = "CreateObject#FIELD_VALUE");
 	}
 
-	macro assertObjectDefinitionName {
-		AssertTextEquals(
-			locator1 = "CreateObject#OBJECT_DEFINITION_NAME",
-			value1 = "${objectName}");
-	}
-
 	macro assertObjectFieldNameIsAutofilled {
 		LexiconEntry.gotoAdd();
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -407,10 +407,6 @@ definition {
 		Alert.viewRequiredField();
 	}
 
-	macro viewEmptyFieldTable {
-		AssertElementPresent(locator1 = "ClientExtension#EMPTY_REMOTE_TABLE_MESSAGE");
-	}
-
 	macro viewErrorValueInvalid {
 		AssertElementPresent(
 			key_className = "${className}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -107,12 +107,6 @@ definition {
 			locator1 = "CreateObject#FIELD_ADDED_ON_BLOCK");
 	}
 
-	macro assertFieldNotPresentInBlock {
-		AssertElementNotPresent(
-			key_fieldLabelName = "${fieldLabelName}",
-			locator1 = "CreateObject#FIELD_ADDED_ON_BLOCK");
-	}
-
 	macro assertLabelBasicInfo {
 		var key_fieldType = "value";
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/CreateObject.macro
@@ -91,10 +91,6 @@ definition {
 		AssertElementPresent(locator1 = "CreateObject#DISABLED_OBJECT_NAME");
 	}
 
-	macro assertDisabledPublishObjectButton {
-		AssertElementPresent(locator1 = "CreateObject#DISABLED_PUBLISH_OBJECT_BUTTON");
-	}
-
 	macro assertEntrySelectedOnRelationshipField {
 		AssertElementPresent(
 			key_entry = "${entry}",

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -2367,7 +2367,7 @@ definition {
 
 		ObjectPortlet.selectCustomObject(label = "Custom Object 65");
 
-		CreateObject.assertDisabledObjectName();
+		AssertElementPresent(locator1 = "CreateObject#DISABLED_OBJECT_NAME");
 	}
 
 	@description = "LPS-135635 - Verify it is not possible to update the Object scope after it is published"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -6649,11 +6649,15 @@ definition {
 
 		ObjectAdmin.openMySubmissions();
 
-		CreateObject.assertObjectNotPresentInSubmissions(objectName = "Custom Object 141635");
+		AssertElementNotPresent(
+			key_submissionName = "Custom Object 141635",
+			locator1 = "WorkflowSubmissions#SUBMISSION_BY_NAME");
 
 		ObjectAdmin.openSubmissions();
 
-		CreateObject.assertObjectNotPresentInSubmissions(objectName = "Custom Object 141635");
+		AssertElementNotPresent(
+			key_submissionName = "Custom Object 141635",
+			locator1 = "WorkflowSubmissions#SUBMISSION_BY_NAME");
 	}
 
 	@description = "LPS-139005 - Verify that pending and completed Object entries with workflow are not displayed on the workflow pages (My Workflow Tasks, My Submissions, and Submissions) when inactivated"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -3194,7 +3194,7 @@ definition {
 
 		CreateObject.checkToggleCollapsible();
 
-		CreateObject.assertToggleCollapsibleChecked();
+		AssertChecked.assertCheckedNotVisible(locator1 = "CreateObject#TOGGLE_COLLAPSIBLE");
 	}
 
 	@description = "LPS-135389 - Verify it is possible to set a different language value for a Field Label"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -1517,7 +1517,9 @@ definition {
 
 			ObjectPortlet.selectCustomObject(label = "Custom Object 156824");
 
-			CreateObject.assertAccountRestrictedFieldDisabled(valueName = "Choose an Option");
+			AssertElementPresent(
+				key_valueName = "Choose an Option",
+				locator1 = "CreateObject#ACCOUNT_RESTRICTED_FIELD_DISABLED");
 
 			AssertElementPresent(locator1 = "CreateObject#TOGGLE_ACCOUNT_RESTRICTION_DISABLED");
 		}

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -1621,7 +1621,9 @@ definition {
 
 		ObjectAdmin.goToLayoutTabOnLayouts();
 
-		CreateObject.assertCannotAddRelationshipTabFirst();
+		LexiconEntry.gotoAddNoSelectFrame();
+
+		AssertElementPresent(locator1 = "CreateObject#DISABLED_TAB_TYPE_RELATIONSHIPS");
 	}
 
 	@description = "LPS-135549 - Verify that it is not possible to create a Field with a duplicated Field Name"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -7086,7 +7086,9 @@ definition {
 			fieldLabelName = "Custom Object 150",
 			pluralLabelName = "");
 
-		CreateObject.assertObjectDefinitionName(objectName = "CustomObject150");
+		AssertTextEquals(
+			locator1 = "CreateObject#OBJECT_DEFINITION_NAME",
+			value1 = "CustomObject150");
 	}
 
 	@description = "LPS-135649 - Verify that when Objects are not scoped by Site it should not be displayed on the Workflow settings from the Site Menu"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -1996,7 +1996,7 @@ definition {
 
 		ObjectPortlet.selectCustomObject(label = "Custom Object 53");
 
-		CreateObject.assertDisabledPublishObjectButton();
+		AssertElementPresent(locator1 = "CreateObject#DISABLED_PUBLISH_OBJECT_BUTTON");
 	}
 
 	@description = "LPS-135549 - Verify it is not possible to save with the first character of the Object Name in lower case"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -3776,7 +3776,9 @@ definition {
 
 		ObjectPortlet.selectCustomObject(label = "Custom Object 96");
 
-		CreateObject.assertPanelCategoryKey(panelCategoryKey = "Control Panel > Users");
+		AssertTextEquals(
+			locator1 = "CreateObject#PANEL_CATEGORY_KEY",
+			value1 = "Control Panel > Users");
 	}
 
 	@description = "LPS-135635 - Verify it is possible to update the Object panel category key after it is published"
@@ -3803,7 +3805,9 @@ definition {
 
 		ObjectPortlet.selectCustomObject(label = "Custom Object 97");
 
-		CreateObject.assertPanelCategoryKey(panelCategoryKey = "Control Panel > Users");
+		AssertTextEquals(
+			locator1 = "CreateObject#PANEL_CATEGORY_KEY",
+			value1 = "Control Panel > Users");
 	}
 
 	@description = "LPS-135635 - Verify it is possible to update the Object plural label after it is published"
@@ -3969,7 +3973,9 @@ definition {
 			locator1 = "ObjectAdmin#SELECT_OBJECT_SCOPE",
 			value1 = "Company");
 
-		CreateObject.assertPanelCategoryKey(panelCategoryKey = "Control Panel > Object");
+		AssertTextEquals(
+			locator1 = "CreateObject#PANEL_CATEGORY_KEY",
+			value1 = "Control Panel > Object");
 	}
 
 	@description = "LPS-135400 - Verify it is possible to update a Relationship"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -1517,7 +1517,7 @@ definition {
 
 			CreateObject.assertAccountRestrictedFieldDisabled(valueName = "Choose an Option");
 
-			CreateObject.viewToogleAccountRestrictionDisabled();
+			AssertElementPresent(locator1 = "CreateObject#TOGGLE_ACCOUNT_RESTRICTION_DISABLED");
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -1261,7 +1261,9 @@ definition {
 
 		CreateObject.deleteFieldOnBlock();
 
-		CreateObject.assertFieldNotPresentInBlock(fieldLabelName = "Custom Field");
+		AssertElementNotPresent(
+			key_fieldLabelName = "Custom Field",
+			locator1 = "CreateObject#FIELD_ADDED_ON_BLOCK");
 	}
 
 	@description = "LPS-135397 - Verify if it's possible to delete a Layout for an Object"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -3965,7 +3965,9 @@ definition {
 
 		CreateObject.assertTitleFieldIsSelected(fieldLabel = "Custom Field");
 
-		CreateObject.assertScopeFieldSelected(fieldScope = "Company");
+		AssertTextEquals(
+			locator1 = "ObjectAdmin#SELECT_OBJECT_SCOPE",
+			value1 = "Company");
 
 		CreateObject.assertPanelCategoryKey(panelCategoryKey = "Control Panel > Object");
 	}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectExportImport.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectExportImport.testcase
@@ -263,7 +263,9 @@ definition {
 
 		ObjectPortlet.selectCustomObject(label = "Imported Object With Scope");
 
-		CreateObject.assertScopeFieldSelected(fieldScope = "Company");
+		AssertTextEquals(
+			locator1 = "ObjectAdmin#SELECT_OBJECT_SCOPE",
+			value1 = "Company");
 
 		CreateObject.assertPanelCategoryKey(panelCategoryKey = "Control Panel > Object");
 	}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectExportImport.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectExportImport.testcase
@@ -267,7 +267,9 @@ definition {
 			locator1 = "ObjectAdmin#SELECT_OBJECT_SCOPE",
 			value1 = "Company");
 
-		CreateObject.assertPanelCategoryKey(panelCategoryKey = "Control Panel > Object");
+		AssertTextEquals(
+			locator1 = "CreateObject#PANEL_CATEGORY_KEY",
+			value1 = "Control Panel > Object");
 	}
 
 	@description = "LPS-142175 - Verify it is not possible to maintain Relationships after importing an Object"

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectPermission.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectPermission.testcase
@@ -1208,7 +1208,7 @@ definition {
 
 		CreateObject.assertDisabledAllFields();
 
-		CreateObject.assertDisabledPublishObjectButton();
+		AssertElementPresent(locator1 = "CreateObject#DISABLED_PUBLISH_OBJECT_BUTTON");
 	}
 
 	@description = "LPS-146759 - Verify it is not possible to update a single Picklist created by the user if the Update Owner permission is removed"


### PR DESCRIPTION
[Remove the Asserts from the macros of the Object.macro](https://issues.liferay.com/browse/LPS-139185)

- assertAccountRestrictedFieldDisabled
- assertCannotAddRelationshipTabFirst
- assertDisabledObjectName
- assertDisabledPublishObjectButton
- assertFieldNotPresentInBlock
- assertObjectDefinitionName
- assertObjectNotPresentInSubmissions
- assertPanelCategoryKey
- assertScopeFieldSelected
- assertToggleCollapsibleChecked
- viewEmptyFieldTable
- viewToogleAccountRestrictionDisabled