### PR TITLE
LPS-174525 - Refactor ObjectAdmin.macro | Master

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -517,12 +517,6 @@ definition {
 		}
 	}
 
-	macro assertObjectActionsNotPresent {
-		AssertElementNotPresent(
-			key_actionLabel = "${actionLabel}",
-			locator1 = "ObjectAdmin#VIEW_ACTIONS_LABEL");
-	}
-
 	macro assertObjectColumnsAreDisplayed {
 		AssertElementPresent(locator1 = "ObjectAdmin#OBJECT_LABEL_COLUMN");
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -475,12 +475,6 @@ definition {
 			value1 = "You do not have permission to delete this relationship.");
 	}
 
-	macro assertClobTypeText {
-		AssertElementPresent(
-			key_clobType = "${clobType}",
-			locator1 = "ObjectAdmin#VIEW_CLOB_TYPE_TEXT_ENTRY");
-	}
-
 	macro assertEntryOnPageNotPresent {
 		AssertElementNotPresent(
 			key_entryName = "${entryName}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -499,12 +499,6 @@ definition {
 			locator1 = "ObjectAdmin#FIELDS_RADIO_OPTION");
 	}
 
-	macro assertNoItemsWereFound {
-		AssertTextEquals(
-			locator1 = "Message#EMPTY_INFO",
-			value1 = "No items were found.");
-	}
-
 	macro assertNoResultsWereFound {
 		AssertTextEquals(
 			locator1 = "Message#EMPTY_STATE_INFO",

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -475,12 +475,6 @@ definition {
 			value1 = "You do not have permission to delete this relationship.");
 	}
 
-	macro assertFieldsTableColumnsAreDisplayed {
-		AssertElementPresent(locator1 = "ObjectAdmin#FIELDS_LABEL_COLUMN");
-
-		AssertElementPresent(locator1 = "ObjectAdmin#FIELDS_TYPE_COLUMN");
-	}
-
 	macro assertFieldTabIsPresent {
 		AssertElementPresent(
 			key_fieldTabName = "${fieldTabName}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -475,12 +475,6 @@ definition {
 			value1 = "You do not have permission to delete this relationship.");
 	}
 
-	macro assertFieldTabIsPresent {
-		AssertElementPresent(
-			key_fieldTabName = "${fieldTabName}",
-			locator1 = "ObjectAdmin#FIELD_TAB_NAME");
-	}
-
 	macro assertKeywordAndText {
 		AssertElementPresent(locator1 = "ObjectAdmin#SEARCHABLE_SECTION_TITLE");
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -475,12 +475,6 @@ definition {
 			value1 = "You do not have permission to delete this relationship.");
 	}
 
-	macro assertEntryOnPageNotPresent {
-		AssertElementNotPresent(
-			key_entryName = "${entryName}",
-			locator1 = "ObjectAdmin#VIEW_ENTRY_NAME_ON_PAGE");
-	}
-
 	macro assertFieldsTableColumnsAreDisplayed {
 		AssertElementPresent(locator1 = "ObjectAdmin#FIELDS_LABEL_COLUMN");
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -610,12 +610,6 @@ definition {
 			value1 = "${description}");
 	}
 
-	macro assertRelationshipTabPresent {
-		AssertElementPresent(
-			key_tabName = "Relationship Tab",
-			locator1 = "ObjectAdmin#ENTRY_RELATIONSHIP_TAB");
-	}
-
 	macro assertRequiredErrorPresent {
 		AssertTextEquals.assertPartialText(
 			locator1 = "TextInput#REQUIRED_ALERT",

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -548,12 +548,6 @@ definition {
 			value1 = "${status}");
 	}
 
-	macro assertObjectDetailsPage {
-		Click(locator1 = "ObjectAdmin#OBJECT_DETAILS_TAB");
-
-		AssertElementPresent(locator1 = "ObjectAdmin#DETAILS_PAGE_TITLE");
-	}
-
 	macro assertObjectEntryFieldValueViaAPI {
 		var actualValue = JSONObject.getObjectEntryFieldValue(
 			attribute = "${attribute}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -610,12 +610,6 @@ definition {
 			value1 = "${description}");
 	}
 
-	macro assertRelationshipTabNotPresent {
-		AssertElementNotPresent(
-			key_tabName = "Relationship Tab",
-			locator1 = "ObjectAdmin#ENTRY_RELATIONSHIP_TAB");
-	}
-
 	macro assertRelationshipTabPresent {
 		AssertElementPresent(
 			key_tabName = "Relationship Tab",

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -8607,7 +8607,9 @@ definition {
 
 		ObjectPortlet.viewEntryDetails(entry = "Entry A");
 
-		ObjectAdmin.assertRelationshipTabPresent();
+		AssertElementPresent(
+			key_tabName = "Relationship Tab",
+			locator1 = "ObjectAdmin#ENTRY_RELATIONSHIP_TAB");
 
 		ObjectAdmin.openObjectAdmin();
 
@@ -8623,7 +8625,9 @@ definition {
 
 		ObjectPortlet.viewEntryDetails(entry = "Entry B");
 
-		ObjectAdmin.assertRelationshipTabPresent();
+		AssertElementPresent(
+			key_tabName = "Relationship Tab",
+			locator1 = "ObjectAdmin#ENTRY_RELATIONSHIP_TAB");
 	}
 
 	@description = "LPS-139005 - Verify that the Relationship tab is displayed again when the child object is reactivated (One to Many)"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -343,7 +343,9 @@ definition {
 
 		ObjectAdmin.addTabFieldsOnLayout(tabName = "Field Tab");
 
-		ObjectAdmin.assertFieldTabIsPresent(fieldTabName = "Field Tab");
+		AssertElementPresent(
+			key_fieldTabName = "Field Tab",
+			locator1 = "ObjectAdmin#FIELD_TAB_NAME");
 	}
 
 	@description = "LPS-139803 - Verify it is possible to add a Object Entry Title Field"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -8413,7 +8413,9 @@ definition {
 
 		ObjectPortlet.viewEntryDetails(entry = "Entry A");
 
-		ObjectAdmin.assertRelationshipTabNotPresent();
+		AssertElementNotPresent(
+			key_tabName = "Relationship Tab",
+			locator1 = "ObjectAdmin#ENTRY_RELATIONSHIP_TAB");
 
 		Navigator.openURL();
 
@@ -8433,7 +8435,9 @@ definition {
 
 		ObjectPortlet.viewEntryDetails(entry = "Entry B");
 
-		ObjectAdmin.assertRelationshipTabNotPresent();
+		AssertElementNotPresent(
+			key_tabName = "Relationship Tab",
+			locator1 = "ObjectAdmin#ENTRY_RELATIONSHIP_TAB");
 	}
 
 	@description = "LPS-139005 - Verify that the Relationship tab is no longer displayed when the child object is inactivated (One to Many)"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -6569,7 +6569,9 @@ definition {
 			menuItem = "View",
 			pageName = "Blank Display Page");
 
-		ObjectAdmin.assertEntryOnPageNotPresent(entryName = "Entry Test");
+		AssertElementNotPresent(
+			key_entryName = "Entry Test",
+			locator1 = "ObjectAdmin#VIEW_ENTRY_NAME_ON_PAGE");
 	}
 
 	@description = "LPS-135649 - Verify that pending and completed Object entries disappears from Workflow Metrics page when they are deleted"
@@ -8081,7 +8083,9 @@ definition {
 			menuItem = "View",
 			pageName = "Blank Display Page");
 
-		ObjectAdmin.assertEntryOnPageNotPresent(entryName = "Entry A");
+		AssertElementNotPresent(
+			key_entryName = "Entry A",
+			locator1 = "ObjectAdmin#VIEW_ENTRY_NAME_ON_PAGE");
 	}
 
 	@description = "LPS-139005 - Verify that the Relationship field will not be displayed to be selected for a Page fragment when the parent object is inactivated"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -5668,7 +5668,9 @@ definition {
 
 		ObjectAdmin.goToFieldsTab();
 
-		ObjectAdmin.assertFieldsTableColumnsAreDisplayed();
+		AssertElementPresent(locator1 = "ObjectAdmin#FIELDS_LABEL_COLUMN");
+
+		AssertElementPresent(locator1 = "ObjectAdmin#FIELDS_TYPE_COLUMN");
 	}
 
 	@description = "LPS-135549 - Verify that the columns Name, System and Status are displayed for the Objects table"

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -5074,7 +5074,9 @@ definition {
 
 		ObjectPortlet.selectCustomObject(label = "Custom Object 118");
 
-		ObjectAdmin.assertObjectDetailsPage();
+		Click(locator1 = "ObjectAdmin#OBJECT_DETAILS_TAB");
+
+		AssertElementPresent(locator1 = "ObjectAdmin#DETAILS_PAGE_TITLE");
 	}
 
 	@description = "LPS-135549 - Verify it is possible to view the Details of an Object by clicking on its name"
@@ -5091,7 +5093,9 @@ definition {
 
 		ObjectPortlet.selectCustomObject(label = "Custom Object 118");
 
-		ObjectAdmin.assertObjectDetailsPage();
+		Click(locator1 = "ObjectAdmin#OBJECT_DETAILS_TAB");
+
+		AssertElementPresent(locator1 = "ObjectAdmin#DETAILS_PAGE_TITLE");
 	}
 
 	@description = "LPS-135390 - Verify it is possible to view an Object with the View permission"

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
@@ -791,7 +791,9 @@ definition {
 
 		ObjectAdmin.deleteActionViaUI(actionLabel = "Action Label");
 
-		ObjectAdmin.assertObjectActionsNotPresent(actionLabel = "Action Label");
+		AssertElementNotPresent(
+			key_actionLabel = "Action Label",
+			locator1 = "ObjectAdmin#VIEW_ACTIONS_LABEL");
 	}
 
 	@description = "LPS-145665 - Verify that you can edit the Action name"
@@ -1327,7 +1329,9 @@ definition {
 
 		ObjectAdmin.assertObjectActions(actionLabel = "Action Label 1");
 
-		ObjectAdmin.assertObjectActionsNotPresent(actionLabel = "Action Label 2");
+		AssertElementNotPresent(
+			key_actionLabel = "Action Label 2",
+			locator1 = "ObjectAdmin#VIEW_ACTIONS_LABEL");
 	}
 
 	@description = "LPS-156343 - Verify that Action can be triggered after disabling the expression"

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectAutoGeneratedLayout.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectAutoGeneratedLayout.testcase
@@ -350,7 +350,9 @@ definition {
 
 		ObjectPortlet.viewClobEntryDetails(clobEntry = "By building a vibrant business, making technology useful, and investing in communities, we make it possible for people to reach their full potential to serve others.");
 
-		ObjectAdmin.assertClobTypeText(clobType = "By building a vibrant business, making technology useful, and investing in communities, we make it possible for people to reach their full potential to serve others.");
+		AssertElementPresent(
+			key_clobType = "By building a vibrant business, making technology useful, and investing in communities, we make it possible for people to reach their full potential to serve others.",
+			locator1 = "ObjectAdmin#VIEW_CLOB_TYPE_TEXT_ENTRY");
 	}
 
 	@description = "LPS-143065 - Verify that when the user click on the file name, the file can be viewed"


### PR DESCRIPTION
[Remove the Asserts from the macros of the ObjectAdmin.macro](https://issues.liferay.com/browse/LPS-174525)

- assertClobTypeText
- assertEntryOnPageNotPresent
- assertFieldsTableColumnsAreDisplayed
- assertFieldTabIsPresent
- assertNoItemsWereFound
- assertObjectActionsNotPresent
- assertObjectDetailsPage
- assertRelationshipTabNotPresent
- assertRelationshipTabPresent