### PR TITLE
LPS-174497 Fix FIELD_REMOVE path related

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldsGroup.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldsGroup.testcase
@@ -1606,7 +1606,9 @@ definition {
 
 		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
 
-		DERenderer.removeRepeatableField(fieldLabel = "Text");
+		DERenderer.removeRepeatableField(
+			fieldLabel = "Text",
+			index = "2");
 
 		Button.clickPublish();
 

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/Fieldsets.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/Fieldsets.testcase
@@ -220,7 +220,7 @@ definition {
 				index = "${n}");
 		}
 
-		AssertElementNotPresent(
+		AssertVisible(
 			key_fieldName = "New Fieldset",
 			key_index = "1",
 			locator1 = "FormFields#FIELD_REMOVE");
@@ -240,7 +240,7 @@ definition {
 				index = "${n}");
 		}
 
-		AssertElementNotPresent(
+		AssertVisible(
 			key_fieldName = "New Fieldset",
 			key_index = "1",
 			locator1 = "FormFields#FIELD_REMOVE");

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/structures/FieldGroups.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/structures/FieldGroups.testcase
@@ -827,7 +827,7 @@ definition {
 				index = "2");
 		}
 
-		AssertElementNotPresent(
+		AssertVisible(
 			key_fieldName = "FieldsGroup",
 			key_index = "1",
 			locator1 = "FormFields#FIELD_REMOVE");

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/translations/LocalizedNestedFieldsWebContent.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/translations/LocalizedNestedFieldsWebContent.testcase
@@ -347,7 +347,7 @@ definition {
 			}
 		}
 
-		AssertElementNotPresent(
+		AssertVisible(
 			key_fieldName = "FieldsGroup",
 			key_index = "1",
 			locator1 = "FormFields#FIELD_REMOVE");
@@ -368,7 +368,7 @@ definition {
 			}
 		}
 
-		AssertElementNotPresent(
+		AssertVisible(
 			key_fieldName = "FieldsGroup",
 			key_index = "1",
 			locator1 = "FormFields#FIELD_REMOVE");


### PR DESCRIPTION
**Ticket:**
[LPS-174497](https://issues.liferay.com/browse/LPS-174497)

**Failing Tests:**
LocalFile.DEFieldsGroup#CanRemoveDuplicatedRepeatableFieldsGroupTranslated 
LocalFile.FieldGroups#SetFieldGroupAsRepeatableAndExecuteOnAWebContent
LocalFile.Fieldsets#FieldsetSetAsRepeatable
LocalFile.LocalizedNestedFieldsWebContent#CheckDuplicatedRepeatableStructureOnWebContent