### PR TITLE
LPS-174830 - Refactor ObjectCustomViews.macro | Master

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
@@ -89,12 +89,6 @@ definition {
 		PortletEntry.save();
 	}
 
-	macro assertColumnLabelPresent {
-		AssertElementPresent(
-			key_columnLabel = "${columnLabel}",
-			locator1 = "ObjectCustomViews#BUILDER_SEARCH_RESULT_COLUMN_LABEL");
-	}
-
 	macro assertColumnNotPresent {
 		AssertElementNotPresent(
 			key_columnName = "${columnName}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
@@ -156,12 +156,6 @@ definition {
 		AssertElementPresent(locator1 = "ObjectCustomViews#OBJECT_VIEW_LABEL");
 	}
 
-	macro assertObjectViewName {
-		AssertElementPresent(
-			locator1 = "ObjectCustomViews#OBJECT_VIEWS_NAME",
-			value1 = "${name}");
-	}
-
 	macro assertObjectViewNotPresent {
 		var key_viewLabel = "${viewLabel}";
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
@@ -95,12 +95,6 @@ definition {
 			locator1 = "ObjectCustomViews#VIEW_BUILDER_SEARCH_RESULT");
 	}
 
-	macro assertColumnNotPresentOnAddColumnModal {
-		AssertElementNotPresent(
-			key_columnName = "${columnOption}",
-			locator1 = "ObjectCustomViews#ADD_COLUMNS_COLUMN_LABEL");
-	}
-
 	macro assertColumnNotPresentOnDefaultSort {
 		AssertElementNotPresent(
 			key_columnName = "${columnName}",

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
@@ -156,12 +156,6 @@ definition {
 		AssertElementPresent(locator1 = "ObjectCustomViews#OBJECT_VIEW_LABEL");
 	}
 
-	macro assertObjectViewNotPresent {
-		var key_viewLabel = "${viewLabel}";
-
-		AssertElementNotPresent(locator1 = "ObjectCustomViews#OBJECT_VIEW_LABEL");
-	}
-
 	macro assertPresentEntriesOnFilters {
 		AssertElementPresent(
 			key_columnName = "${filterBy}",

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
@@ -218,7 +218,9 @@ definition {
 
 		SelectFrame(locator1 = "IFrame#IFRAME");
 
-		ObjectCustomViews.assertColumnLabelPresent(columnLabel = "Author");
+		AssertElementPresent(
+			key_columnLabel = "Author",
+			locator1 = "ObjectCustomViews#BUILDER_SEARCH_RESULT_COLUMN_LABEL");
 	}
 
 	@description = "LPS-135394 - Verify it is possible to cancel the creation of a View"
@@ -1085,7 +1087,9 @@ definition {
 
 			ObjectCustomViews.goToViewsBuilderTab();
 
-			ObjectCustomViews.assertColumnLabelPresent(columnLabel = "Relationship Edit");
+			AssertElementPresent(
+				key_columnLabel = "Relationship Edit",
+				locator1 = "ObjectCustomViews#BUILDER_SEARCH_RESULT_COLUMN_LABEL");
 		}
 	}
 
@@ -2027,7 +2031,9 @@ definition {
 
 		ObjectCustomViews.goToViewsBuilderTab();
 
-		ObjectCustomViews.assertColumnLabelPresent(columnLabel = "Publishing House");
+		AssertElementPresent(
+			key_columnLabel = "Publishing House",
+			locator1 = "ObjectCustomViews#BUILDER_SEARCH_RESULT_COLUMN_LABEL");
 	}
 
 	@description = "LPS-144472 - Verify it is possible to sort the column entries as ascending or descending"

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
@@ -837,7 +837,9 @@ definition {
 
 		ObjectCustomViews.deleteObjectCustomViewViaUI(viewLabel = "Custom Views");
 
-		ObjectCustomViews.assertObjectViewNotPresent(viewLabel = "Custom Views");
+		AssertElementNotPresent(
+			locator1 = "ObjectCustomViews#OBJECT_VIEW_LABEL",
+			viewLabel = "Custom Views");
 	}
 
 	@description = "LPS-135394 - Verify it is possible to drag the columns"
@@ -1736,7 +1738,9 @@ definition {
 
 		ObjectCustomViews.assertObjectView(viewLabel = "View A");
 
-		ObjectCustomViews.assertObjectViewNotPresent(viewLabel = "Custom B");
+		AssertElementNotPresent(
+			locator1 = "ObjectCustomViews#OBJECT_VIEW_LABEL",
+			viewLabel = "Custom B");
 	}
 
 	@description = "LPS-144472 - Verify it is possible to search when press enter key on Default Sort"

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
@@ -2736,7 +2736,9 @@ definition {
 
 		ObjectCustomViews.goToViewsDetails(label = "Custom View 152051 (Copy)");
 
-		ObjectCustomViews.assertObjectViewName(name = "Custom View 152051 (Copy)");
+		AssertElementPresent(
+			locator1 = "ObjectCustomViews#OBJECT_VIEWS_NAME",
+			value1 = "Custom View 152051 (Copy)");
 	}
 
 	@description = "LPS-146028 - Verify that when the user duplicate a view, the Mark As Default option comes inactivated"

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
@@ -1639,7 +1639,9 @@ definition {
 
 		ObjectCustomViews.assertColumnVisibleOnAddColumnModal(columnOption = "Author");
 
-		ObjectCustomViews.assertColumnNotPresentOnAddColumnModal(columnOption = "Create Date");
+		AssertElementNotPresent(
+			key_columnName = "Create Date",
+			locator1 = "ObjectCustomViews#ADD_COLUMNS_COLUMN_LABEL");
 	}
 
 	@description = "LPS-144472 - Verify it is possible to search columns to a New Default Sort modal"


### PR DESCRIPTION
[Remove the Asserts from the macros of the ObjectCustomViews.macro](https://issues.liferay.com/browse/LPS-174830)

- assertColumnLabelPresent
- assertColumnNotPresentOnAddColumnModal
- assertObjectViewName
- assertObjectViewNotPresent