### PR TITLE
LPS-174886 Refactor objects teardown to delete definitions with relationships

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -746,6 +746,20 @@ definition {
 			userPassword = ${userPassword});
 	}
 
+	macro deleteAllRelationships {
+		var objectDefinitionIdList = JSONObject.getAllObjectDefinitionsId();
+
+		for (var objectDefinitionId : list ${objectDefinitionIdList}) {
+			var relationshipIdList = JSONObject.getObjectRelationships(objectDefinitionId = ${objectDefinitionId});
+
+			if (${relationshipIdList} != "") {
+				for (var relationshipId : list ${relationshipIdList}) {
+					JSONObject.deleteRelationship(objectRelationshipId = ${relationshipId});
+				}
+			}
+		}
+	}
+
 	macro deleteCategorizationViaUI {
 		Click(locator1 = "ObjectAdmin#CATEGORIZATION_DROPDOWN");
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -741,6 +741,8 @@ definition {
 	}
 
 	macro deleteAllCustomObjectsViaAPI {
+		ObjectAdmin.deleteAllRelationships();
+
 		JSONObject.deleteAllCustomObjects(
 			userEmailAddress = ${userEmailAddress},
 			userPassword = ${userPassword});

--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
@@ -578,6 +578,28 @@ definition {
 		''';
 	}
 
+	@summary = "Get a list of all Object Definitions"
+	macro getAllObjectDefinitionsId {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (!(isSet(userEmailAddress))) {
+			var userEmailAddress = "test@liferay.com";
+		}
+
+		if (!(isSet(userPassword))) {
+			var userPassword = "test";
+		}
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions \
+				-u ${userEmailAddress}:${userPassword}
+		''';
+
+		var objectDefinitionIdList = JSONCurlUtil.get(${curl}, "$.items[*].id");
+
+		return ${objectDefinitionIdList};
+	}
+
 	@summary = "Get a objectDefinitionId by name"
 	macro getObjectDefinitionId {
 		Variables.assertDefined(parameterList = ${name});

--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
@@ -531,6 +531,27 @@ definition {
 		JSONCurlUtil.delete(${curl});
 	}
 
+	macro deleteRelationship {
+		Variables.assertDefined(parameterList = ${objectRelationshipId});
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (!(isSet(userEmailAddress))) {
+			var userEmailAddress = "test@liferay.com";
+		}
+
+		if (!(isSet(userPassword))) {
+			var userPassword = "test";
+		}
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-relationships/${objectRelationshipId} \
+				-u ${userEmailAddress}:${userPassword}
+		''';
+
+		JSONCurlUtil.delete(${curl});
+	}
+
 	@summary = "This calls the JSON WS API to filter an entry in an object"
 	macro filterObjectEntry {
 		var portalURL = JSONCompany.getPortalURL();

--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
@@ -681,6 +681,32 @@ definition {
 		return ${objectId};
 	}
 
+	@summary = "Get the list of an Object Definition based of its ID"
+	macro getObjectRelationships {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (!(isSet(userEmailAddress))) {
+			var userEmailAddress = "test@liferay.com";
+		}
+
+		if (!(isSet(userPassword))) {
+			var userPassword = "test";
+		}
+
+		if (!(isSet(objectDefinitionId))) {
+			var objectDefinitionId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = ${objectName});
+		}
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/object-relationships \
+				-u ${userEmailAddress}:${userPassword}
+		''';
+
+		var relationshipIdList = JSONCurlUtil.get(${curl}, "$.items..id");
+
+		return ${relationshipIdList};
+	}
+
 	macro getPicklistId {
 		var portalURL = JSONCompany.getPortalURL();
 


### PR DESCRIPTION
**Ticket:**
[LPS-174886](https://issues.liferay.com/browse/LPS-174886)

**Motivation:**
The Objects teardown does not work was intended when the Object has a relationship, that should be deleted before deleting the definition itself.
This can turn into a bigger problem if we have an unsuccessful run at CI, since it'll re-run in a not clean state. For example, we can see that at this particular printscreen, the test is running for the third time, adding a Layout for the same Object Definition that was not previously deleted:
![before10](https://user-images.githubusercontent.com/57020720/217108320-15829e20-2fec-47b0-9ff1-a3740f90f01d.jpeg)

**Proposed Solution:**
Add a macro to the `ObjectAdmin#deleteAllCustomObjectsViaAPI` using available endpoints to delete all Relationships, regardless the parent being Custom or System.