### PR TITLE
LPS - 174666, LPS-173424, LPS-174493

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -234,9 +234,7 @@ definition {
 
 		Click(locator1 = "ObjectAdmin#ENTRY_CHOOSE_OPTION");
 
-		Click(
-			key_picklistOption = ${picklistOption},
-			locator1 = "ObjectAdmin#ENTRY_PICKLIST_OPTION");
+		MenuItem.clickNoError(menuItem = ${picklistOption});
 
 		if (IsElementPresent(key_text = ${saveName}, locator1 = "Button#ANY")) {
 			Click(

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
@@ -89,9 +89,7 @@ definition {
 
 		Click(locator1 = "ObjectCustomViews#VIEW_MODAL_CONTENT");
 
-		Click(
-			key_picklistOption = ${filterBy},
-			locator1 = "Picklist#PICKLIST_KEBAB_MENU_OPTION");
+		MenuItem.clickNoError(menuItem = ${filterBy});
 
 		if (isSet(filterType)) {
 			Click(

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectNotifications.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectNotifications.macro
@@ -30,6 +30,27 @@ definition {
 			locator1 = "TextInput#ANY",
 			value1 = ${subject});
 
+		if (isSet(description)) {
+			Type(
+				key_text = "description",
+				locator1 = "TextArea#ANY",
+				value1 = ${description});
+		}
+
+		if (isSet(cc)) {
+			Type(
+				key_text = "CC",
+				locator1 = "TextInput#ANY",
+				value1 = ${cc});
+		}
+
+		if (isSet(bcc)) {
+			Type(
+				key_text = "BCC",
+				locator1 = "TextInput#ANY",
+				value1 = ${bcc});
+		}
+
 		Type(
 			locator1 = "CKEditor#BODY_FIELD_IFRAME",
 			value1 = ${emailBody});
@@ -82,6 +103,27 @@ definition {
 				key_text = "Name",
 				locator1 = "TextInput#ANY",
 				value1 = ${name});
+		}
+
+		if (isSet(description)) {
+			Type(
+				key_text = "description",
+				locator1 = "TextArea#ANY",
+				value1 = ${description});
+		}
+
+		if (isSet(cc)) {
+			Type(
+				key_text = "CC",
+				locator1 = "TextInput#ANY",
+				value1 = ${cc});
+		}
+
+		if (isSet(bcc)) {
+			Type(
+				key_text = "BCC",
+				locator1 = "TextInput#ANY",
+				value1 = ${bcc});
 		}
 
 		if (isSet(entryTo)) {
@@ -198,6 +240,8 @@ definition {
 			AssertElementPresent(
 				key_text = ${emailBody},
 				locator1 = "CKEditor#BODY_TEXT");
+
+			SelectFrameTop();
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/Picklist.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/Picklist.macro
@@ -201,9 +201,7 @@ definition {
 		var key_picklistItemName = ${picklistItemName};
 		var key_picklistItemKey = ${picklistItemKey};
 
-		if (IsElementNotPresent(locator1 = "Picklist#VIEW_PICKLIST_ITEM")) {
-			Picklist.gotoPicklistView(picklistName = ${picklistItemName});
-		}
+		WaitForPageLoad();
 
 		AssertElementPresent(locator1 = "Picklist#VIEW_PICKLIST_ITEM");
 	}
@@ -304,7 +302,7 @@ definition {
 			key_picklistName = ${picklistName},
 			locator1 = "Picklist#SELECT_PICKLIST_VIEW");
 
-		Click.javaScriptClick(locator1 = "Picklist#GOTO_PICKLIST_VIEW");
+		MenuItem.clickNoError(menuItem = "View");
 	}
 
 	macro optionsPicklist {
@@ -312,14 +310,11 @@ definition {
 			key_picklistName = ${picklistName},
 			locator1 = "Picklist#PICKLIST_KEBAB_MENU");
 
-		Click.javaScriptClick(
-			key_picklistOption = ${picklistOption},
-			locator1 = "Picklist#PICKLIST_KEBAB_MENU_OPTION");
+		MenuItem.clickNoError(menuItem = ${menuItem});
 	}
 
 	macro optionsPicklistItem {
 		var key_itemKey = ${itemKey};
-		var key_picklistItemOption = ${picklistItemOption};
 
 		SelectFrameTop();
 
@@ -327,7 +322,7 @@ definition {
 
 		Click.javaScriptClick(locator1 = "Picklist#PICKLIST_ITEM_KEBAB_MENU");
 
-		Click.javaScriptClick(locator1 = "Picklist#PICKLIST_ITEM_KEBAB_MENU_OPTION");
+		MenuItem.clickNoError(menuItem = ${menuItem});
 	}
 
 	macro searchPicklist {
@@ -359,7 +354,7 @@ definition {
 	macro updatePicklistItemName {
 		Picklist.optionsPicklistItem(
 			itemKey = ${itemkey},
-			picklistItemOption = "View");
+			menuItem = "View");
 
 		SelectFrameTop();
 

--- a/modules/apps/object/object-test/src/testFunctional/paths/Picklist.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/Picklist.path
@@ -36,11 +36,6 @@
 		<td></td>
 	</tr>
 	<tr>
-		<td>PICKLIST_KEBAB_MENU_OPTION</td>
-		<td>//button[(@class='dropdown-item') and contains(.,'${key_picklistOption}')]</td>
-		<td></td>
-	</tr>
-	<tr>
 		<td>UPDATE_PICKLIST_NAME</td>
 		<td>//input[@aria-describedby] | //*[text()='Name']/..//input[@type="text"]</td>
 		<td></td>
@@ -53,11 +48,6 @@
 	<tr>
 		<td>SELECT_PICKLIST_VIEW</td>
 		<td>//a[contains(.,'${key_picklistName}')]/../../..//button</td>
-		<td></td>
-	</tr>
-	<tr>
-		<td>GOTO_PICKLIST_VIEW</td>
-		<td>//button[(@class='dropdown-item') and contains(.,'View')]</td>
 		<td></td>
 	</tr>
 	<tr>
@@ -93,11 +83,6 @@
 	<tr>
 		<td>IFRAME_PICKLIST_ITEM_MODAL</td>
 		<td>//div[contains(@class,'modal-content')]</td>
-		<td></td>
-	</tr>
-	<tr>
-		<td>PICKLIST_ITEM_KEBAB_MENU_OPTION</td>
-		<td>//div[contains(.,'${key_itemKey}')]/..//button[contains(.,'${key_picklistItemOption}')]</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectNotificationsUpgrade.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectNotificationsUpgrade.testcase
@@ -1,0 +1,96 @@
+@component-name = "portal-upgrades"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Upgrades Object";
+
+	setUp {
+		SignIn.signIn();
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		AssertLocation(value1 = "${portalURL}/web/guest?SM_USER=test@liferay.com");
+
+		SearchAdministration.executeReindex();
+	}
+
+	@priority = 5
+	test ViewNotificationTemplateAfterUpgrade7413U33 {
+		property data.archive.type = "data-archive-object";
+		property database.types = "mariadb,mysql,postgresql,sqlserver";
+		property portal.version = "7.4.13.u33";
+
+		task ("View an email notification template after Upgrade") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Notifications",
+				panel = "Control Panel",
+				portlet = "Templates");
+
+			ObjectNotifications.viewNotificationTemplateDetails(
+				bcc = "test@liferay.com",
+				cc = "test@liferay.com",
+				description = "Description",
+				emailBody = "Email Body",
+				entryTo = "test@liferay.com",
+				fromAddress = "test@liferay.com",
+				fromName = "Test Test",
+				name = "Notification Template",
+				subject = "Subject");
+
+			AssertElementPresent(
+				key_dataSource = "Custom Object2",
+				locator1 = "ObjectNotifications#DATA_SOURCE_ATTACHMENTS");
+
+			AssertTextPresent(
+				locator1 = "ObjectNotifications#FIELD_ATTACHMENTS_OBJECT",
+				value1 = "Custom Field Attachment");
+		}
+
+		task ("Edit an email notification template after Upgrade") {
+			Navigator.gotoBack();
+
+			ObjectNotifications.editNotificationTemplate(
+				bcc = "test2@liferay.com",
+				cc = "test2@liferay.com",
+				description = "Description for Template Edit After Upgrade",
+				emailBody = "Email Body Edit",
+				entryTo = "test2@liferay.com",
+				externalReferenceCode = "ERC Edit",
+				fromAddress = "Liferay Edit",
+				fromName = "Test Test Edit",
+				name = "Notification Template Edit After Upgrade",
+				notificationTemplateName = "Notification Template",
+				subject = "Subject Edit");
+
+			PortletEntry.save();
+		}
+
+		task ("Add a new email notification template after Upgrade") {
+			ObjectNotifications.addNewNotificationTemplate(
+				bcc = "test@liferay.com",
+				cc = "test@liferay.com",
+				description = "Description for Template Add After Upgrade",
+				emailBody = "Email Body",
+				entryTo = "test@liferay.com",
+				fromAddress = "Liferay",
+				fromName = "Test Test",
+				name = "Notification Template Add After Upgrade",
+				notificationType = "Email",
+				objectLabelAttachment = "Custom Object2",
+				subject = "Subject After Upgrade");
+
+			ObjectNotifications.addNotificationTemplateAttachment(objectLabel = "Custom Object2");
+
+			PortletEntry.save();
+		}
+
+		task ("Delete both email notification templates after Upgrade") {
+			ObjectNotifications.deleteNotificationTemplate(templateName = "Notification Template Edit After Upgrade");
+
+			ObjectNotifications.deleteNotificationTemplate(templateName = "Notification Template Add After Upgrade");
+		}
+	}
+
+}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectPermission.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectPermission.testcase
@@ -211,8 +211,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "Delete");
+			menuItem = "Delete",
+			picklistName = "Picklist Test");
 
 		Picklist.assertPicklistNotPresent(picklistName = "Picklist Test");
 	}
@@ -394,8 +394,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Custom Picklist 148938",
-			picklistOption = "Delete");
+			menuItem = "Delete",
+			picklistName = "Custom Picklist 148938");
 
 		Picklist.assertPicklistNotPresent(picklistName = "Custom Picklist 148938");
 	}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectUpgrade.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectUpgrade.testcase
@@ -1,0 +1,63 @@
+@component-name = "portal-upgrades"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Upgrades Object";
+
+	setUp {
+		SignIn.signIn();
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		AssertLocation(value1 = "${portalURL}/web/guest?SM_USER=test@liferay.com");
+
+		SearchAdministration.executeReindex();
+	}
+
+	@ignore = "Test Stub"
+	@priority = "5"
+	test ViewActionWithNotificationAfterUpgrade7413U33 {
+		property data.archive.type = "data-archive-object";
+		property database.types = "mariadb,mysql,postgresql,sqlserver";
+		property portal.version = "7.4.13.u33";
+
+		// TODO LPS-174664 ViewActionWithNotificationAfterUpgrade7413U33
+
+	}
+
+	@ignore = "Test Stub"
+	@priority = "5"
+	test ViewObjectDefinitionAfterUpgrade7413U33 {
+		property data.archive.type = "data-archive-object";
+		property database.types = "mariadb,mysql,postgresql,sqlserver";
+		property portal.version = "7.4.13.u33";
+
+		// TODO LPS-174662 ViewObjectDefinitionAfterUpgrade7413U33
+
+	}
+
+	@ignore = "Test Stub"
+	@priority = "5"
+	test ViewObjectEntryAfterUpgrade7413U33 {
+		property data.archive.type = "data-archive-object";
+		property database.types = "mariadb,mysql,postgresql,sqlserver";
+		property portal.version = "7.4.13.u33";
+
+		// TODO LPS-174662 ViewObjectEntryAfterUpgrade7413U33
+
+	}
+
+	@ignore = "Test Stub"
+	@priority = "5"
+	test ViewPicklistAfterUpgrade7413U33 {
+		property data.archive.type = "data-archive-object";
+		property database.types = "mariadb,mysql,postgresql,sqlserver";
+		property portal.version = "7.4.13.u33";
+
+		// TODO LPS-174662 ViewPicklistAfterUpgrade7413U33
+
+	}
+
+}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectUpgrade.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectUpgrade.testcase
@@ -17,7 +17,7 @@ definition {
 	}
 
 	@ignore = "Test Stub"
-	@priority = "5"
+	@priority = 5
 	test ViewActionWithNotificationAfterUpgrade7413U33 {
 		property data.archive.type = "data-archive-object";
 		property database.types = "mariadb,mysql,postgresql,sqlserver";
@@ -28,7 +28,7 @@ definition {
 	}
 
 	@ignore = "Test Stub"
-	@priority = "5"
+	@priority = 5
 	test ViewObjectDefinitionAfterUpgrade7413U33 {
 		property data.archive.type = "data-archive-object";
 		property database.types = "mariadb,mysql,postgresql,sqlserver";
@@ -39,7 +39,7 @@ definition {
 	}
 
 	@ignore = "Test Stub"
-	@priority = "5"
+	@priority = 5
 	test ViewObjectEntryAfterUpgrade7413U33 {
 		property data.archive.type = "data-archive-object";
 		property database.types = "mariadb,mysql,postgresql,sqlserver";
@@ -49,15 +49,112 @@ definition {
 
 	}
 
-	@ignore = "Test Stub"
-	@priority = "5"
+	@priority = 5
 	test ViewPicklistAfterUpgrade7413U33 {
 		property data.archive.type = "data-archive-object";
 		property database.types = "mariadb,mysql,postgresql,sqlserver";
 		property portal.version = "7.4.13.u33";
 
-		// TODO LPS-174662 ViewPicklistAfterUpgrade7413U33
+		task ("View a Picklist after Upgrade") {
+			Picklist.gotoPicklists();
 
+			Picklist.optionsPicklist(
+				menuItem = "View",
+				picklistName = "Custom Picklist");
+
+			SelectFrame(locator1 = "Picklist#IFRAME_PICKLIST_MODAL");
+
+			for (var itemNumber : list "1,2,3") {
+				Picklist.assertPicklistItem(
+					picklistItemKey = "picklistItem${itemNumber}",
+					picklistItemName = "Picklist Item ${itemNumber}");
+			}
+		}
+
+		task ("Edit a Picklist and items") {
+			SelectFrameTop();
+
+			Picklist.updatePicklistName(picklistName = "Custom Picklist Edit After Upgrade");
+
+			Type(
+				key_text = "External Reference Code",
+				locator1 = "TextInput#ANY",
+				value1 = "ERC Edit After Upgrade");
+
+			PortletEntry.save();
+
+			Picklist.optionsPicklist(
+				menuItem = "View",
+				picklistName = "Custom Picklist Edit After Upgrade");
+
+			for (var itemNumber : list "1,2,3") {
+				Picklist.updatePicklistItemName(
+					itemkey = "picklistItem${itemNumber}",
+					newItemName = "Picklist Item ${itemNumber} Edit After Upgrade");
+
+				PortletEntry.save();
+			}
+		}
+
+		task ("Add a new item to the existing Picklist and create a brand new Picklist") {
+			Picklist.addPicklistItemViaUI(picklistItemName = "New Picklist Item");
+
+			PortletEntry.save();
+
+			Picklist.gotoPicklists();
+
+			Picklist.addPicklistViaUI(picklistName = "Custom Picklist Add After Upgrade");
+
+			Picklist.gotoPicklistView(picklistName = "Custom Picklist Add After Upgrade");
+
+			for (var itemNumber : list "1,2") {
+				Picklist.addPicklistItemViaUI(picklistItemName = "Picklist After Upgrade Item ${itemNumber}");
+
+				PortletEntry.save();
+			}
+		}
+
+		task ("Delete items from both Picklists") {
+			Picklist.optionsPicklistItem(
+				itemKey = "picklistAfterUpgradeItem2",
+				menuItem = "Delete");
+
+			PortletEntry.save();
+
+			SelectFrameTop();
+
+			Picklist.gotoPicklistView(picklistName = "Custom Picklist Edit After Upgrade");
+
+			Picklist.optionsPicklistItem(
+				itemKey = "picklistItem2",
+				menuItem = "Delete");
+
+			PortletEntry.save();
+		}
+
+		task ("Delete any Custom Objects that use a picklist and then delete all picklists") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectAdmin.deleteCustomObjectViaUI(
+				labelName = "Custom Object3",
+				objectName = "CustomObject3");
+
+			Picklist.gotoPicklists();
+
+			Picklist.optionsPicklist(
+				menuItem = "Delete",
+				picklistName = "Custom Picklist Edit After Upgrade");
+
+			Picklist.optionsPicklist(
+				menuItem = "Delete",
+				picklistName = "Custom Picklist Add After Upgrade");
+
+			for (var picklistName : list "Custom Picklist Add After Upgrade,Custom Picklist Edit After Upgrade") {
+				AssertElementNotPresent(
+					key_picklistName = ${picklistName},
+					locator1 = "Picklist#VIEW_PICKLIST");
+			}
+		}
 	}
 
 }

--- a/modules/apps/object/object-test/src/testFunctional/tests/Picklist.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/Picklist.testcase
@@ -41,8 +41,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.addPicklistItemViaUI(
 			picklistItemKey = "PicklistItemKeyTest",
@@ -63,8 +63,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.updatePicklistName(picklistName = "Update Picklist Test");
 
@@ -190,8 +190,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "Delete");
+			menuItem = "Delete",
+			picklistName = "Picklist Test");
 
 		Picklist.assertPicklistNotPresent(picklistName = "Picklist Test");
 	}
@@ -211,12 +211,12 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.optionsPicklistItem(
 			itemKey = "PicklistItemKeyTest",
-			picklistItemOption = "Delete");
+			menuItem = "Delete");
 
 		Picklist.assertPicklistItemNotPresent(
 			picklistItemKey = "PicklistItemKeyTest",
@@ -352,8 +352,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.addPicklistItemViaUI(picklistItemKey = "PicklistItemKeyTest");
 
@@ -391,12 +391,12 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.optionsPicklistItem(
 			itemKey = "itemKeyName",
-			picklistItemOption = "View");
+			menuItem = "View");
 
 		Picklist.assertDisableKey(keyName = "itemKeyName");
 	}
@@ -435,8 +435,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.searchPicklistItem(picklistItemName = "Test 2");
 
@@ -462,12 +462,12 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.optionsPicklistItem(
 			itemKey = "itemTest",
-			picklistItemOption = "View");
+			menuItem = "View");
 
 		Picklist.addLanguageOnPicklistItem(
 			itemName = "Teste de entrada",
@@ -478,12 +478,12 @@ definition {
 		Refresh();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.optionsPicklistItem(
 			itemKey = "itemTest",
-			picklistItemOption = "View");
+			menuItem = "View");
 
 		Picklist.assertPicklistItemByLanguage(
 			nameItem = "Teste de entrada",
@@ -498,8 +498,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.addPicklistItemWithTranslationViaUI(
 			defaultLanguage = "en_US",
@@ -512,12 +512,12 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.optionsPicklistItem(
 			itemKey = "itemTest",
-			picklistItemOption = "View");
+			menuItem = "View");
 
 		Picklist.assertItemNameAndItemKeyOnModal(
 			itemKey = "itemTest",
@@ -536,8 +536,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.addLanguageOnPicklist(
 			itemName = "Teste na lista",
@@ -548,8 +548,8 @@ definition {
 		Refresh();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.assertPicklistNameByLanguage(
 			nameItem = "Teste na lista",
@@ -571,8 +571,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.assertPicklistItemInTable(
 			picklistItemKey = "entryTest",
@@ -587,8 +587,8 @@ definition {
 		Refresh();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.assertPicklistItemInTable(
 			picklistItemKey = "entryTest",
@@ -607,8 +607,8 @@ definition {
 		Picklist.assertPicklist(picklistName = "Picklist Test");
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.updatePicklistName(picklistName = "Update Picklist");
 
@@ -627,8 +627,8 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.assertPicklistDetails(title = "Basic Info");
 	}
@@ -646,12 +646,12 @@ definition {
 		Picklist.gotoPicklists();
 
 		Picklist.optionsPicklist(
-			picklistName = "Picklist Test",
-			picklistOption = "View");
+			menuItem = "View",
+			picklistName = "Picklist Test");
 
 		Picklist.optionsPicklistItem(
 			itemKey = "PicklistItemKeyTest",
-			picklistItemOption = "View");
+			menuItem = "View");
 
 		IFrame.selectTopFrame();
 
@@ -735,7 +735,7 @@ definition {
 		task ("Go to Picklist Item and add a new language") {
 			Picklist.optionsPicklistItem(
 				itemKey = "PicklistItemKeyTest",
-				picklistItemOption = "View");
+				menuItem = "View");
 
 			Picklist.addLanguageOnPicklistItem(
 				itemName = "Teste de entrada",
@@ -912,7 +912,7 @@ definition {
 
 		Picklist.optionsPicklistItem(
 			itemKey = "PicklistItemKeyTest",
-			picklistItemOption = "View");
+			menuItem = "View");
 
 		Picklist.addLanguageOnPicklistItem(
 			itemName = "Teste de entrada",
@@ -1052,7 +1052,7 @@ definition {
 
 		Picklist.optionsPicklistItem(
 			itemKey = "PicklistItemKeyTest",
-			picklistItemOption = "View");
+			menuItem = "View");
 
 		Picklist.addLanguageOnPicklistItem(
 			itemName = "Teste de entrada",

--- a/test.properties
+++ b/test.properties
@@ -5432,6 +5432,10 @@
     test.batch.names[object]=\
         central-requirements-jdk8,\
         functional-tomcat90-mysql57-jdk8,\
+        functional-upgrade-tomcat90-mariadb102-jdk8,\
+        functional-upgrade-tomcat90-mysql57-jdk8,\
+        functional-upgrade-tomcat90-postgresql134-jdk8,\
+        functional-upgrade-tomcat90-sqlserver2017-jdk8,\
         modules-integration-mysql57-jdk8,\
         modules-semantic-versioning-jdk8,\
         modules-unit-jdk8,\
@@ -5446,6 +5450,13 @@
             (testray.component.names ~ "Object") OR \
             (testray.main.component.name ~ "Object")\
         )
+
+    test.batch.run.property.query[functional-upgrade-*][object]=\
+        (\
+            (portal.acceptance != quarantine) AND \
+            (portal.upstream == true)\
+        ) AND \
+        (testray.main.component.name == "Upgrades Object")
 
     #
     # Object Environments
@@ -10192,7 +10203,8 @@
         Plugin Installer
 
     testray.team.object.component.names=\
-        Object
+        Object,\
+        Upgrades Object
 
     testray.team.publications.component.names=\
         Publications,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-174666
https://issues.liferay.com/browse/LPS-173424
https://issues.liferay.com/browse/LPS-174493

This is a continuation of https://github.com/liferay-bpm-qa/liferay-portal/pull/395 with Picklist test and updates. 

Reasoning for the Picklist edits is because the paths were written in a way that would always default to the first picklist or item in the list regardless of the variable used. This wasn't an issue at first since all of the picklist tests either only use one picklist/item or the test uses the first one in the list. Instead of rewriting the paths, I found an existing macro that could be used and removed the now unused ones.  