### PR TITLE
LPS-170529, LPS-162182 | Add tests CannotFilterWithERCField, CanCreateFilterByRelationshipColumnFromSystemObject

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomViews.testcase
@@ -388,6 +388,92 @@ definition {
 		}
 	}
 
+	@description = "LPS-170529 - Verify if it is possible to create a filter by relationship columns made from the system objects to custom objects"
+	@priority = 5
+	test CanCreateFilterByRelationshipColumnFromSystemObject {
+		property portal.acceptance = "true";
+
+		task ("Given a system object related to another custom object, in a One-to-Many relationship") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object 170529",
+				objectName = "CustomObject170529",
+				pluralLabelName = "Custom Objects 170529");
+
+			ObjectAdmin.addObjectRelationshipViaAPI(
+				objectName_1 = "CustomObject170529",
+				objectName_2 = "CustomObject170529",
+				relationshipLabel = "Relationship",
+				relationshipName = "relationship",
+				relationshipType = "oneToMany");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Text",
+				fieldLabelName = "Custom Field",
+				fieldName = "customObjectField",
+				fieldType = "String",
+				isRequired = "false",
+				objectName = "CustomObject170529");
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject170529");
+
+			ObjectAdmin.addObjectSingleFieldEntryViaAPI(
+				fieldName = "Custom Field 170529",
+				objectName = "CustomObject170529",
+				value = "Entry Test");
+
+			JSONAccountEntry.addAccountEntry(
+				accountEntryName = "Account Name 1",
+				accountEntryType = "Business");
+
+			JSONAccountEntry.addAccountEntry(
+				accountEntryName = "Account Name 2",
+				accountEntryType = "Business");
+		}
+
+		task ("When the user creates a filter and the relationship column can be selected as the filter") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 170529");
+
+			CreateObject.selectTitleField(fieldLabel = "Custom Field");
+
+			CreateObject.saveObject();
+
+			ObjectCustomViews.goToViewsTab();
+
+			ObjectCustomViews.addObjectViewViaUI(viewName = "Custom Views");
+
+			ObjectCustomViews.goToViewsDetails(label = "Custom Views");
+
+			ObjectCustomViews.markViewAsDefault();
+
+			ObjectCustomViews.goToViewsBuilderTab();
+
+			ObjectCustomViews.addColumnsViaUI(addColumns = "Relationship");
+
+			ObjectCustomViews.addColumnsViaUI(addColumns = "Custom Field");
+
+			ObjectCustomViews.goToFiltersTab();
+
+			ObjectCustomViews.addNewFilterViaUI(
+				filterBy = "Relationship",
+				filterType = "Includes",
+				filterValue = "Account Name 1");
+		}
+
+		task ("Then the user can filter relationship entries") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObject170529");
+
+			AssertElementPresent(
+				key_tabName = "Account Name 1",
+				locator1 = "ObjectAdmin#ANY_TAB_ON_ENTRY");
+
+			AssertElementNotPresent(
+				key_tabName = "Account Name 2",
+				locator1 = "ObjectAdmin#ANY_TAB_ON_ENTRY");
+		}
+	}
+
 	@description = "LPS-166585 - Verify that it's possible to create a filter using the relationship field of the object"
 	@priority = 5
 	test CanCreateFilterUsingRelationshipField {

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -1212,6 +1212,41 @@ definition {
 		}
 	}
 
+	@description = "LPS-162182 - Verify that it is not possible to edit ERC fields in Objects management."
+	@priority = 4
+	test CannotFilterWithERCField {
+		task ("Given a custom object is created") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object 162182",
+				objectName = "CustomObject162182",
+				pluralLabelName = "Custom Objects 162182");
+		}
+
+		task ("When the user goes to Views Tab and Creates a new filter") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 162182");
+
+			ObjectCustomViews.goToViewsTab();
+
+			ObjectCustomViews.addObjectViewViaUI(viewName = "Custom Views");
+
+			ObjectCustomViews.goToViewsDetails(label = "Custom Views");
+
+			ObjectCustomViews.goToFiltersTab();
+
+			Click(locator1 = "ObjectCustomViews#ADD_BUTTON_FILTERS");
+
+			Click(locator1 = "ObjectCustomViews#VIEW_MODAL_CONTENT");
+		}
+
+		task ("Then the user is unable to filter by ERC") {
+			AssertElementNotPresent(
+				key_picklistOption = "External Reference Code",
+				locator1 = "Picklist#PICKLIST_KEBAB_MENU_OPTION");
+		}
+	}
+
 	@description = "This is a use case for LPS-156704 - Verify that the user cannot insert an invalid date in an object field."
 	@priority = 2
 	test CannotInsertInvalidDate {


### PR DESCRIPTION
CanCreateFilterByRelationshipColumnFromSystemObject
[LPS-170529](https://issues.liferay.com/browse/LPS-170529)
Test Scenario:
Given: An system object related to another custom object, in a One-to-Many relationship
When: The user creates a filter and the relationship column can be selected as the filter
Then: The user can filter relationship entries

CannotFilterWithERCField
[LPS-162182](https://issues.liferay.com/browse/LPS-162182)
Test Steps:
Given a custom object is created
And the user goes to Views Tab and Creates a new filter
Then the user is unable to filter by ERC