### PR TITLE
LPS-173960 | Remove test from quarantine

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/cpdynamicdatalists/CPDynamicdatalists.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/cpdynamicdatalists/CPDynamicdatalists.testcase
@@ -300,8 +300,6 @@ definition {
 
 	@priority = 3
 	test AddListAndRecordWithEventsPredefinedDataDefinition {
-		property portal.upstream = "quarantine";
-
 		DDLList.openDynamicDataListsAdmin(siteURLKey = "guest");
 
 		DDLList.addCP(
@@ -429,8 +427,6 @@ definition {
 
 	@priority = 3
 	test AddListAndRecordWithIssuesTrackingPredefinedDataDefinition {
-		property portal.upstream = "quarantine";
-
 		DDLList.openDynamicDataListsAdmin(siteURLKey = "guest");
 
 		DDLList.addCP(
@@ -501,8 +497,6 @@ definition {
 
 	@priority = 3
 	test AddListAndRecordWithMeetingMinutesPredefinedDataDefinition {
-		property portal.upstream = "quarantine";
-
 		DDLList.openDynamicDataListsAdmin(siteURLKey = "guest");
 
 		DDLList.addCP(
@@ -872,8 +866,6 @@ definition {
 
 	@priority = 4
 	test AddListRecordWithDocumentsAndMediaField {
-		property portal.upstream = "quarantine";
-
 		DDLList.openDynamicDataListsAdmin(siteURLKey = "guest");
 
 		DDLDataDefinition.addCP(ddlDataDefinitionName = "Data Definition");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/pgdynamicdatalists/PGDynamicdatalists.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/pgdynamicdatalists/PGDynamicdatalists.testcase
@@ -221,8 +221,6 @@ definition {
 	@description = "This is a use case for LPS-58893."
 	@priority = 3
 	test AddListWithDocumentsAndMediaField {
-		property portal.upstream = "quarantine";
-
 		DDLList.openDynamicDataListsAdmin(siteURLKey = "guest");
 
 		DDLDataDefinition.addCP(ddlDataDefinitionName = "Data Definition");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/usecase/DynamicdatalistsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/usecase/DynamicdatalistsUsecase.testcase
@@ -1145,8 +1145,6 @@ definition {
 
 	@priority = 4
 	test AssertGuestCannotEditRecord {
-		property portal.upstream = "quarantine";
-
 		DDLList.openDynamicDataListsAdmin(siteURLKey = "guest");
 
 		DDLDataDefinition.addCP(
@@ -3126,8 +3124,6 @@ definition {
 	@description = "This is a use case for LPS-60155."
 	@priority = 5
 	test ViewRequiredNestedDocumentsAndMediaField {
-		property portal.upstream = "quarantine";
-
 		DDLList.openDynamicDataListsAdmin(siteURLKey = "guest");
 
 		DDLDataDefinition.addCP(ddlDataDefinitionName = "Data Definition Name");


### PR DESCRIPTION
Ticket:
https://issues.liferay.com/browse/LPS-173960

Tests affecteds:
[LocalFile.CPDynamicdatalists#AddListAndRecordWithEventsPredefinedDataDefinition]
[LocalFile.CPDynamicdatalists#AddListAndRecordWithIssuesTrackingPredefinedDataDefinition]
[LocalFile.CPDynamicdatalists#AddListAndRecordWithMeetingMinutesPredefinedDataDefinition]
[LocalFile.CPDynamicdatalists#AddListRecordWithDocumentsAndMediaField]
[LocalFile.DynamicdatalistsUsecase#AssertGuestCannotEditRecord]
[LocalFile.DynamicdatalistsUsecase#ViewRequiredNestedDocumentsAndMediaField]
[LocalFile.PGDynamicdatalists#AddListWithDocumentsAndMediaField]