### PR TITLE
LPS-181944 ObjectActions | Test Automation | Master

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
@@ -165,6 +165,63 @@ definition {
 		}
 	}
 
+	@description = "LPS-173537 - Verify creating a custom object entry triggers an action to add an Account entry"
+	@priority = 5
+	test CanAddAccountEntryAfterCreatingCustomObjectEntry {
+		property portal.acceptance = "true";
+
+		task ("Given a Custom Object with a custom field") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object 180082",
+				objectName = "CustomObject180082",
+				pluralLabelName = "Custom Objects 180082");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Text",
+				fieldLabelName = "Custom Field",
+				fieldName = "customObjectField",
+				fieldType = "String",
+				isRequired = "true",
+				objectName = "CustomObject180082");
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject180082");
+		}
+
+		task ("And given an action to create a new Account entry after adding an entry on Custom Object") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 180082");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.addObjectActionViaUI(
+				actionLabel = "Custom Action",
+				active = "true",
+				inputMethod = "true",
+				inputValue = "Account Name,Guest",
+				objectLabel = "Account",
+				thenAction = "Add an Object Entry",
+				whenAction = "On After Add");
+		}
+
+		task ("When the user creates a custom object entry") {
+			ObjectAdmin.addObjectSingleFieldEntryViaAPI(
+				fieldName = "customObjectField",
+				objectName = "CustomObject180082",
+				value = "Entry Test");
+		}
+
+		task ("Then the action is triggered and an Account entry is added") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObject180082");
+
+			ObjectPortlet.viewEntry(entry = "Entry Test");
+
+			Account.openAccountsAdmin();
+
+			LexiconEntry.viewEntryName(rowEntry = "Account Name");
+		}
+	}
+
 	@description = "LPS-173537 - Verify deleting a custom object entry triggers an action to add an Account entry"
 	@priority = 5
 	test CanAddAccountEntryAfterDeletingCustomObjectEntry {

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
@@ -165,6 +165,69 @@ definition {
 		}
 	}
 
+	@description = "LPS-173537 - Verify deleting a custom object entry triggers an action to add an Account entry"
+	@priority = 5
+	test CanAddAccountEntryAfterDeletingCustomObjectEntry {
+		property portal.acceptance = "true";
+
+		task ("Given a Custom Object and an object entry") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object 180087",
+				objectName = "CustomObject180087",
+				pluralLabelName = "Custom Object 180087");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Text",
+				fieldLabelName = "Custom Field",
+				fieldName = "customObjectField",
+				fieldType = "String",
+				isRequired = "true",
+				objectName = "CustomObject180087");
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject180087");
+
+			ObjectAdmin.addObjectSingleFieldEntryViaAPI(
+				fieldName = "customObjectField",
+				objectName = "CustomObject180087",
+				value = "Entry Test");
+		}
+
+		task ("And given an action to add an Account entry after deleting a custom object entry") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 180087");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.addObjectActionViaUI(
+				actionLabel = "Custom Action",
+				active = "true",
+				inputMethod = "true",
+				inputValue = "Account Name,Guest",
+				objectLabel = "Account",
+				thenAction = "Add an Object Entry",
+				whenAction = "On After Delete");
+		}
+
+		task ("When the user deletes a custom object entry") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObject180087");
+
+			ObjectPortlet.deleteEntry(entry = "Entry Test");
+		}
+
+		task ("Then the action is triggered and an Account entry is added") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObject180087");
+
+			AssertElementNotPresent(
+				locator1 = "ObjectAdmin#ANY_TAB_ON_ENTRY",
+				value1 = "Entry Test");
+
+			Account.openAccountsAdmin();
+
+			LexiconEntry.viewEntryName(rowEntry = "Account Name");
+		}
+	}
+
 	@description = "LPS-173537 - Verify creating a custom object entry triggers an action to update an Account entry"
 	@priority = 5
 	test CanAddAccountEntryAfterUpdatingCustomObjectEntry {

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
@@ -3556,6 +3556,95 @@ definition {
 			actionLabel = "Update Action Label");
 	}
 
+	@description = "LPS-181944 - Verify updating a Commerce Product entry triggers an action to update the Commerce Product entry"
+	@priority = 5
+	test CanUpdateCommerceProductEntryAfterUpdatingCommerceProductEntry {
+		property portal.acceptance = "true";
+
+		task ("Given a minium site and Commerce Product") {
+			CommerceAccelerators.initializeNewSiteViaAccelerator(siteName = "Minium");
+
+			ApplicationsMenu.gotoSite(site = "Minium");
+
+			ApplicationsMenu.gotoPortlet(
+				category = "Product Management",
+				panel = "Commerce",
+				portlet = "Products");
+
+			CPCommerceCatalog.newProductsEntry(
+				productCatalog = "Minium",
+				productName = "Simple T-Shirt",
+				productType = "Simple");
+
+			ApplicationsMenu.gotoSite(site = "Minium");
+
+			CommerceAcceleratorsInitializer.viewMiniumCardName(productName = "Simple T-Shirt");
+
+			CommerceAcceleratorsInitializer.gotoMiniumProductDetailsPage(productName = "Simple T-Shirt");
+
+			FrontStore.assertProductDetails(
+				productFullDescription = "Simple T-Shirt Full Description",
+				productName = "Simple T-Shirt",
+				productShortDescription = "Simple T-Shirt Short Description");
+		}
+
+		task ("And given an action to update a Commerce Product entry after updating a Commerce Product entry") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectSystemObject(label = "Commerce Product");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.addObjectActionViaUI(
+				actionLabel = "Custom Action",
+				actionName = "customAction",
+				active = "true",
+				fieldName = "Short Description",
+				inputMethod = "true",
+				inputValue = "Updated Description",
+				objectLabel = "Commerce Product",
+				thenAction = "Update an Object Entry",
+				whenAction = "On After Update");
+		}
+
+		task ("When the user updates any Commerce Product entry") {
+			CommerceNavigator.gotoPortlet(
+				category = "Product Management",
+				portlet = "Products");
+
+			CommerceProducts.searchProduct(search = "Simple T-Shirt");
+
+			CommerceNavigator.gotoEntry(entryName = "Simple T-Shirt");
+
+			CommerceEntry.addProductDescription(
+				productFullDescription = "This is a New Full Description",
+				productShortDescription = "This is a New Short Description",
+				publishProduct = "true");
+		}
+
+		task ("Then the action is triggered and the Commerce Product entry changed is updated") {
+			ApplicationsMenu.gotoSite(site = "Minium");
+
+			CommerceAcceleratorsInitializer.gotoMiniumProductDetailsPage(productName = "Simple T-Shirt");
+
+			FrontStore.assertProductDetails(
+				productFullDescription = "Simple T-Shirt Full Description",
+				productName = "Simple T-Shirt",
+				productShortDescription = "Updated Description");
+
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectSystemObject(label = "Commerce Product");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.assertObjectActions(
+				actionActive = "Yes",
+				actionLabel = "Custom Action",
+				status = "Success");
+		}
+	}
+
 	@description = "LPS-156346 - Verify that the expression works with Groovy Script."
 	@priority = 5
 	test CanUseExpressionWithGroovyScript {

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
@@ -106,6 +106,86 @@ definition {
 		}
 	}
 
+	@description = "LPS-181943 - Verify deleting a Commerce Product entry triggers an action to add a Commerce Product Group entry"
+	@priority = 5
+	test CanAddCommerceProductGroupEntryAfterDeletingCommerceProductEntry {
+		property portal.acceptance = "true";
+
+		task ("Given a minium site and Commerce Product object") {
+			CommerceAccelerators.initializeNewSiteViaAccelerator(siteName = "Minium");
+
+			ApplicationsMenu.gotoSite(site = "Minium");
+
+			ApplicationsMenu.gotoPortlet(
+				category = "Product Management",
+				panel = "Commerce",
+				portlet = "Products");
+
+			CPCommerceCatalog.newProductsEntry(
+				productCatalog = "Minium",
+				productName = "Simple T-Shirt",
+				productType = "Simple");
+
+			ApplicationsMenu.gotoSite(site = "Minium");
+
+			CommerceAcceleratorsInitializer.viewMiniumCardName(productName = "Simple T-Shirt");
+
+			CommerceAcceleratorsInitializer.gotoMiniumProductDetailsPage(productName = "Simple T-Shirt");
+
+			FrontStore.assertProductDetails(
+				productFullDescription = "Simple T-Shirt Full Description",
+				productName = "Simple T-Shirt",
+				productShortDescription = "Simple T-Shirt Short Description");
+		}
+
+		task ("And given an action to add a Commerce Product Group entry after deleting a Commerce Product entry") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectSystemObject(label = "Commerce Product");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.addObjectActionViaUI(
+				actionLabel = "Custom Action",
+				actionName = "customAction",
+				active = "true",
+				inputMethod = "true",
+				inputValue = "Value Test",
+				objectLabel = "Commerce Product Group",
+				thenAction = "Add an Object Entry",
+				whenAction = "On After Delete");
+		}
+
+		task ("When the user deletes a Commerce Product entry") {
+			CommerceNavigator.gotoPortlet(
+				category = "Product Management",
+				portlet = "Products");
+
+			CommerceProducts.searchProduct(search = "Simple T-Shirt");
+
+			CommerceProducts.deleteProductsEntry(key_value = "Simple T-Shirt");
+		}
+
+		task ("Then the action is triggered and a Commerce Product Group entry is added") {
+			CommerceNavigator.gotoPortlet(
+				category = "Pricing",
+				portlet = "Product Groups");
+
+			LexiconEntry.viewEntryName(rowEntry = "Value Test");
+
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectSystemObject(label = "Commerce Product");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.assertObjectActions(
+				actionActive = "Yes",
+				actionLabel = "Custom Action",
+				status = "Success");
+		}
+	}
+
 	@description = "LPS-180070 - Verify creating a Commerce Product entry triggers an action to add a user"
 	@priority = 5
 	test CanAddUserAfterCreatingCommerceProductEntry {

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
@@ -106,6 +106,128 @@ definition {
 		}
 	}
 
+	@description = "LPS-173537 - Verify creating an Account entry triggers an action to add a second Account entry"
+	@priority = 5
+	test CanAddAccountEntryAfterCreatingAccountEntry {
+		property portal.acceptance = "true";
+
+		task ("Given a Account object and given an action to add a new Account entry after creating an Account entry") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object 180195",
+				objectName = "CustomObject180195",
+				pluralLabelName = "Custom Objects 180195");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Integer",
+				fieldLabelName = "Custom Field",
+				fieldName = "customField",
+				fieldType = "Integer",
+				isRequired = "false",
+				objectName = "CustomObject180195");
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject180195");
+
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 180195");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.addObjectActionViaUI(
+				actionLabel = "Custom Action",
+				actionName = "CustomAction",
+				active = "true",
+				inputMethod = "true",
+				inputValue = "Object entry added,Business",
+				objectLabel = "Account",
+				thenAction = "Add an Object Entry",
+				whenAction = "On After Add");
+		}
+
+		task ("When the user creates an Account entry") {
+			ObjectAdmin.addObjectSingleFieldEntryViaAPI(
+				fieldName = "customField",
+				objectName = "CustomObject180195",
+				value = 0);
+		}
+
+		task ("Then the action is triggered and a second Account entry is added") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 180195");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.assertObjectActions(
+				actionActive = "Yes",
+				actionLabel = "Custom Action",
+				status = "Success");
+		}
+	}
+
+	@description = "LPS-173537 - Verify creating a custom object entry triggers an action to update an Account entry"
+	@priority = 5
+	test CanAddAccountEntryAfterUpdatingCustomObjectEntry {
+		property portal.acceptance = "true";
+
+		task ("Given a Custom Object and an object entry") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object 180083",
+				objectName = "CustomObject180083",
+				pluralLabelName = "Custom Objects 180083");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Text",
+				fieldLabelName = "Custom Field",
+				fieldName = "customObjectField",
+				fieldType = "String",
+				isRequired = "true",
+				objectName = "CustomObject180083");
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject180083");
+
+			ObjectAdmin.addObjectSingleFieldEntryViaAPI(
+				fieldName = "customObjectField",
+				objectName = "CustomObject180083",
+				value = "Entry Test");
+		}
+
+		task ("And given an action to add an Account entry after updating a custom object entry") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 180083");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.addObjectActionViaUI(
+				actionLabel = "Custom Action",
+				active = "true",
+				inputMethod = "true",
+				inputValue = "Account Name,Guest",
+				objectLabel = "Account",
+				thenAction = "Add an Object Entry",
+				whenAction = "On After Update");
+		}
+
+		task ("When the user updates a custom object entry") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObject180083");
+
+			ObjectAdmin.goToActionDetails(viewEntry = "Entry Test");
+
+			ObjectAdmin.editEntryName(newEntryValue = "Entry Test Edited");
+		}
+
+		task ("Then the action is triggered and an Account entry is added") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObject180083");
+
+			ObjectPortlet.viewEntry(entry = "Entry Test Edited");
+
+			Account.openAccountsAdmin();
+
+			LexiconEntry.viewEntryName(rowEntry = "Account Name");
+		}
+	}
+
 	@description = "LPS-181943 - Verify deleting a Commerce Product entry triggers an action to add a Commerce Product Group entry"
 	@priority = 5
 	test CanAddCommerceProductGroupEntryAfterDeletingCommerceProductEntry {
@@ -3362,65 +3484,6 @@ definition {
 			ObjectAdmin.assertObjectActions(
 				actionActive = "Yes",
 				actionLabel = "Custom Update Action",
-				status = "Success");
-		}
-	}
-
-	@description = "LPS-173537 - Verify creating an Account entry triggers an action to add a second Account entry"
-	@priority = 5
-	test CanAddAccountEntryAfterCreatingAccountEntry {
-		property portal.acceptance = "true";
-
-		task ("Given a Account object and given an action to add a new Account entry after creating an Account entry") {
-			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object 180195",
-				objectName = "CustomObject180195",
-				pluralLabelName = "Custom Objects 180195");
-
-			ObjectAdmin.addObjectFieldViaAPI(
-				fieldBusinessType = "Integer",
-				fieldLabelName = "Custom Field",
-				fieldName = "customField",
-				fieldType = "Integer",
-				isRequired = "false",
-				objectName = "CustomObject180195");
-
-			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject180195");
-
-			ObjectAdmin.openObjectAdmin();
-
-			ObjectPortlet.selectCustomObject(label = "Custom Object 180195");
-
-			ObjectAdmin.goToActionsTab();
-
-			ObjectAdmin.addObjectActionViaUI(
-				actionLabel = "Custom Action",
-				actionName = "CustomAction",
-				active = "true",
-				inputMethod = "true",
-				inputValue = "Object entry added,Business",
-				objectLabel = "Account",
-				thenAction = "Add an Object Entry",
-				whenAction = "On After Add");
-		}
-
-		task ("When the user creates an Account entry") {
-			ObjectAdmin.addObjectSingleFieldEntryViaAPI(
-				fieldName = "customField",
-				objectName = "CustomObject180195",
-				value = 0);
-		}
-
-		task ("Then the action is triggered and a second Account entry is added") {
-			ObjectAdmin.openObjectAdmin();
-
-			ObjectPortlet.selectCustomObject(label = "Custom Object 180195");
-
-			ObjectAdmin.goToActionsTab();
-
-			ObjectAdmin.assertObjectActions(
-				actionActive = "Yes",
-				actionLabel = "Custom Action",
 				status = "Success");
 		}
 	}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
@@ -3366,6 +3366,65 @@ definition {
 		}
 	}
 
+	@description = "LPS-173537 - Verify creating an Account entry triggers an action to add a second Account entry"
+	@priority = 5
+	test CanAddAccountEntryAfterCreatingAccountEntry {
+		property portal.acceptance = "true";
+
+		task ("Given a Account object and given an action to add a new Account entry after creating an Account entry") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object 180195",
+				objectName = "CustomObject180195",
+				pluralLabelName = "Custom Objects 180195");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Integer",
+				fieldLabelName = "Custom Field",
+				fieldName = "customField",
+				fieldType = "Integer",
+				isRequired = "false",
+				objectName = "CustomObject180195");
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject180195");
+
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 180195");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.addObjectActionViaUI(
+				actionLabel = "Custom Action",
+				actionName = "CustomAction",
+				active = "true",
+				inputMethod = "true",
+				inputValue = "Object entry added,Business",
+				objectLabel = "Account",
+				thenAction = "Add an Object Entry",
+				whenAction = "On After Add");
+		}
+
+		task ("When the user creates an Account entry") {
+			ObjectAdmin.addObjectSingleFieldEntryViaAPI(
+				fieldName = "customField",
+				objectName = "CustomObject180195",
+				value = 0);
+		}
+
+		task ("Then the action is triggered and a second Account entry is added") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 180195");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.assertObjectActions(
+				actionActive = "Yes",
+				actionLabel = "Custom Action",
+				status = "Success");
+		}
+	}
+
 	@description = "LPS-169994 - Verify that a permitted user can manually trigger a standalone action"
 	@priority = 5
 	test CanTriggerStandaloneActionWithPermission {


### PR DESCRIPTION
Using macro/path from #732 
Extracting tests from #722 #692

- [LPS-181943](https://issues.liferay.com/browse/LPS-181943) ObjectActions#CanAddCommerceProductGroupEntryAfterDeletingCommerceProductEntry
- [LPS-181944](https://issues.liferay.com/browse/LPS-181944) ObjectActions#CanUpdateCommerceProductEntryAfterUpdatingCommerceProductEntry
- [LPS-180195](https://issues.liferay.com/browse/LPS-180195) ObjectActions#CanAddAccountEntryAfterCreatingAccountEntry
- [LPS-180082](https://issues.liferay.com/browse/LPS-180082) ObjectActions#CanAddAccountEntryAfterCreatingCustomObjectEntry
- [LPS-180083](https://issues.liferay.com/browse/LPS-180083) ObjectActions#CanAddAccountEntryAfterUpdatingCustomObjectEntry
- [LPS-180087](https://issues.liferay.com/browse/LPS-180087) ObjectActions#CanAddAccountEntryAfterDeletingCustomObjectEntry

The tests have been adapted to use the same macro