### PR TITLE
LPS-185729 - Remove Quarantine | Data Engine | Master

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/Localizable.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/fields/Localizable.testcase
@@ -596,8 +596,6 @@ definition {
 	@description = "This is a test for LRQA-66427. This test check it's not possible to translate a field with Localizable property set as Off in a simple field and a Field Group into a Fieldset"
 	@priority = 5
 	test ValidateNotTranslatableOnFieldset {
-		property portal.upstream = "quarantine";
-
 		DataEngine.gotoCreateNewFieldset();
 
 		FormViewBuilder.editFieldSetName(fieldSetName = "New Fieldset");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/cpdynamicdatalists/CPDynamicdatalists.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/cpdynamicdatalists/CPDynamicdatalists.testcase
@@ -557,8 +557,8 @@ definition {
 
 	@priority = 5
 	test AddListAndRecordWithToDoPredefinedDataDefinition {
-		property portal.acceptance = "quarantine";
-		property portal.upstream = "quarantine";
+		property portal.acceptance = "true";
+		property portal.upstream = "true";
 		property test.name.skip.portal.instance = "CPDynamicdatalists#AddListAndRecordWithToDoPredefinedDataDefinition";
 
 		DDLList.openDynamicDataListsAdmin(siteURLKey = "guest");


### PR DESCRIPTION
- [LPS-185729](https://issues.liferay.com/browse/LPS-185729) - CPDynamicdatalists#AddListAndRecordWithToDoPredefinedDataDefinition

- [LPS-185737](https://issues.liferay.com/browse/LPS-185737) - Localizable#ValidateNotTranslatableOnFieldset