### PR TITLE
LPS-178371 | Test fix | Master

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomLayouts.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomLayouts.macro
@@ -28,6 +28,8 @@ definition {
 				key_titleFieldName = ${selectEntry},
 				locator1 = "CreateObject#SELECT_ENTRY_IN_RELATIONSHIP_TAB");
 
+			WaitForSPARefresh();
+
 			Refresh();
 		}
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomLayouts.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomLayouts.testcase
@@ -124,7 +124,7 @@ definition {
 		property ci.retries.disabled = "true";
 		property portal.acceptance = "true";
 
-		task ("Given a related object with Custom Layout and Relationship tab (Many to Many)") {
+		task ("Given a custom object that contains a simple field and a relationship itself (Many to Many)") {
 			ObjectAdmin.addObjectViaAPI(
 				labelName = "Custom Object 171597",
 				objectName = "CustomObject171597",
@@ -145,11 +145,13 @@ definition {
 				relationshipName = "relationship",
 				relationshipType = "manyToMany");
 
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject171597");
+		}
+
+		task ("And given a custom layout for the custom object") {
 			ObjectAdmin.addObjectLayoutViaAPI(
 				layoutName = "Custom Layout 171597",
 				objectName = "CustomObject171597");
-
-			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject171597");
 
 			ObjectAdmin.openObjectAdmin();
 
@@ -184,7 +186,7 @@ definition {
 			PortletEntry.save();
 		}
 
-		task ("When add the entry on Relationship tab") {
+		task ("And given two custom object entries") {
 			for (var letter : list "A,B") {
 				ObjectAdmin.addObjectSingleFieldEntryViaAPI(
 					fieldName = "customField",
@@ -193,7 +195,9 @@ definition {
 			}
 
 			ObjectAdmin.goToCustomObject(objectName = "CustomObject171597");
+		}
 
+		task ("When relating the entries") {
 			ObjectPortlet.viewEntryDetails(entry = "Entry Test A");
 
 			Click(
@@ -201,9 +205,13 @@ definition {
 				locator1 = "ObjectAdmin#ENTRY_RELATIONSHIP_TAB");
 
 			ObjectCustomLayouts.addEntryOnRelationshipTab(selectEntry = "Entry Test B");
+
+			WaitForElementPresent(
+				key_fieldLabel = "Entry Test B",
+				locator1 = "ObjectAdmin#VIEW_OBJECT_FIELD_LABEL");
 		}
 
-		task ("Then the new entry is saved on the Relationship Tab Parent and the entry is present on Relationship Tab Child") {
+		task ("Then the entry is related as Parent and the other one is related as Child") {
 			AssertElementPresent(
 				key_fieldLabel = "Entry Test B",
 				locator1 = "ObjectAdmin#VIEW_OBJECT_FIELD_LABEL");

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomLayouts.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomLayouts.testcase
@@ -1028,7 +1028,7 @@ definition {
 		property ci.retries.disabled = "true";
 		property portal.acceptance = "true";
 
-		task ("Given a related object with Custom Layout and Relationship tab") {
+		task ("Given a custom object that contains a simple field and a relationship itself") {
 			ObjectAdmin.addObjectViaAPI(
 				labelName = "Custom Object 171628",
 				objectName = "CustomObject171628",
@@ -1049,6 +1049,10 @@ definition {
 				relationshipName = "relationship",
 				relationshipType = "oneToMany");
 
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject171628");
+		}
+
+		task ("And given a custom layout for the custom object") {
 			ObjectAdmin.addObjectLayoutViaAPI(
 				layoutName = "Custom Layout 171628",
 				objectName = "CustomObject171628");
@@ -1084,8 +1088,10 @@ definition {
 				tabName = "Relationship Tab");
 
 			PortletEntry.save();
+		}
 
-			for (var letter : list "A,B,C,D,E") {
+		task ("And given some custom object entries") {
+			for (var letter : list "A,B,C") {
 				ObjectAdmin.addObjectSingleFieldEntryViaAPI(
 					fieldName = "customField",
 					objectName = "CustomObject171628",
@@ -1093,37 +1099,21 @@ definition {
 			}
 
 			ObjectAdmin.goToCustomObject(objectName = "CustomObject171628");
-
-			ObjectPortlet.viewEntryDetails(entry = "Entry Test A");
 		}
 
 		task ("When selecting existing entries from the Relationship Tab") {
+			ObjectPortlet.viewEntryDetails(entry = "Entry Test A");
+
 			ObjectAdmin.gotoRelationshipsTab();
 
-			LexiconEntry.gotoAdd();
-
-			Click(
-				key_kebabOption = "Select Existing One",
-				locator1 = "ObjectAdmin#KEBAB_MENU_OPTION");
-
-			SelectFrame(locator1 = "IFrame#MODAL_BODY");
-		}
-
-		task ("Then all entries created show on Select Existing One and the entry selected is saved on the Relationship Tab") {
-			for (var letter : list "B,C,D,E") {
-				AssertElementPresent(
-					key_titleFieldName = "Entry Test ${letter}",
-					locator1 = "CreateObject#SELECT_ENTRY_IN_RELATIONSHIP_TAB");
-			}
-
-			ClickNoError(
-				key_titleFieldName = "Entry Test C",
-				locator1 = "CreateObject#SELECT_ENTRY_IN_RELATIONSHIP_TAB");
+			ObjectCustomLayouts.addEntryOnRelationshipTab(selectEntry = "Entry Test C");
 
 			WaitForElementPresent(
 				key_fieldLabel = "Entry Test C",
 				locator1 = "ObjectAdmin#VIEW_OBJECT_FIELD_LABEL");
+		}
 
+		task ("Then assert the entry added before on the Relationship Tab") {
 			AssertElementPresent(
 				key_fieldLabel = "Entry Test C",
 				locator1 = "ObjectAdmin#VIEW_OBJECT_FIELD_LABEL");

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectRelationships.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectRelationships.testcase
@@ -2163,7 +2163,7 @@ definition {
 		property portal.acceptance = "true";
 		property test.name.skip.portal.instance = "ObjectRelationships#CanSeeRelatedEntriesOnTab";
 
-		task ("Given an object related to itself, in a Many-to-Many relationship and a custom entry") {
+		task ("Given a custom object that contains a simple field and a relationship itself (Many to Many)") {
 			ObjectAdmin.addObjectViaAPI(
 				labelName = "Custom Object 163657",
 				objectName = "CustomObject163657",
@@ -2184,6 +2184,10 @@ definition {
 				relationshipName = "relationship",
 				relationshipType = "manyToMany");
 
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject163657");
+		}
+
+		task ("And given a custom layout for the custom object") {
 			ObjectAdmin.addObjectLayoutViaAPI(
 				layoutName = "Layout Name",
 				objectName = "CustomObject163657");
@@ -2219,31 +2223,33 @@ definition {
 			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject163657");
 		}
 
-		task ("When the user relates the entry to another entry") {
+		task ("And given two custom object entries") {
 			for (var fieldEntry : list "A,B") {
 				ObjectAdmin.addObjectSingleFieldEntryViaAPI(
 					fieldName = "customObjectField",
 					objectName = "CustomObject163657",
-					value = "Entry ${fieldEntry}");
+					value = "Entry Test ${fieldEntry}");
 			}
 
 			ObjectAdmin.goToCustomObject(objectName = "CustomObject163657");
+		}
 
-			ObjectPortlet.viewEntryDetails(entry = "Entry A");
+		task ("When selecting existing entries from the Relationship Tab") {
+			ObjectPortlet.viewEntryDetails(entry = "Entry Test A");
 
 			ObjectPortlet.gotoRelationshipTab();
 
-			CreateObject.addRelationshipAndSelectEntry(titleFieldName = "Entry B");
+			ObjectCustomLayouts.addEntryOnRelationshipTab(selectEntry = "Entry Test B");
+
+			WaitForElementPresent(
+				key_fieldLabel = "Entry Test B",
+				locator1 = "ObjectAdmin#VIEW_OBJECT_FIELD_LABEL");
 		}
 
-		task ("Then all related entries to the entry must be displayed on the relationship tab") {
-			WaitForVisible(
-				key_entry = "Entry B",
-				locator1 = "ObjectPortlet#ENTRY_VALUE");
-
+		task ("Then assert the entry created before on the Relationship Tab") {
 			AssertElementPresent(
-				key_relatedObject = "Entry B",
-				locator1 = "CreateObject#VIEW_RELATED_OBJECT_ON_RELATIONSHIP_FIELD");
+				key_fieldLabel = "Entry Test B",
+				locator1 = "ObjectAdmin#VIEW_OBJECT_FIELD_LABEL");
 		}
 	}
 


### PR DESCRIPTION
Ticket: [LPS-178371](https://issues.liferay.com/browse/LPS-178371)

**Details:**
All fixes are to fix the failure on CI. I believe that the error happens because CI does not see the table out of the modal. So after the refresh, the testcase will wait for the page load and the element.

I took the opportunity to refactor the names of the tasks, remove the steps unnecessary, and organized them.