### PR TITLE
Test Fix | LPS-194280

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/VisualizeObjectCollectionDisplay.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/VisualizeObjectCollectionDisplay.macro
@@ -16,6 +16,23 @@ definition {
 	}
 
 	macro mapFragment {
+		PageEditor.addFragment(
+			collectionName = "Content Display",
+			fragmentName = "Collection Display");
+
+		PageEditor.editCollectionDisplay(
+			fragmentName = "Collection Display",
+			infoListProviderName = ${pluralLabelName});
+
+		Refresh();
+
+		PageEditor.addFragmentToCollectionDisplay(
+			collectionName = "Basic Components",
+			entryTitle = "",
+			fragmentName = "Heading");
+
+		VisualizeObjectCollectionDisplay.openHeading();
+
 		Select(
 			locator1 = "VisualizeObjectCollectionDisplay#MAP_FRAGMENT",
 			value1 = ${fieldLabel});

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -4971,8 +4971,8 @@ definition {
 			subtype = "Custom Object 116");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 116",
-			fieldLabel = "Custom Field");
+			fieldLabel = "Custom Field",
+			pluralLabelName = "Custom Objects 116");
 
 		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Custom Field");
 
@@ -5223,8 +5223,8 @@ definition {
 			subtype = "Custom Object 141623");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 141623",
-			fieldLabel = "Custom Field");
+			fieldLabel = "Custom Field",
+			pluralLabelName = "Custom Objects 141623");
 
 		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Custom Field");
 
@@ -7027,8 +7027,8 @@ definition {
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 142598",
-			fieldLabel = "Custom Field");
+			fieldLabel = "Custom Field",
+			pluralLabelName = "Custom Objects 142598");
 
 		PageEditor.publish();
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -4970,13 +4970,9 @@ definition {
 			displayPageName = "Blank Display Page",
 			subtype = "Custom Object 116");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Custom Field");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 116",
+			fieldLabel = "Custom Field");
 
 		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Custom Field");
 
@@ -5226,13 +5222,9 @@ definition {
 			displayPageName = "Blank Display Page",
 			subtype = "Custom Object 141623");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Custom Field");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 141623",
+			fieldLabel = "Custom Field");
 
 		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Custom Field");
 
@@ -7034,17 +7026,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 142598");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Custom Field");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 142598",
+			fieldLabel = "Custom Field");
 
 		PageEditor.publish();
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectDisplayPage.testcase
@@ -48,17 +48,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Blank Page");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 203");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Custom Field");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 203",
+			fieldLabel = "Custom Field");
 
 		AssertElementPresent(
 			key_entry = "We make it possible for people to reach their full potential to serve others.",
@@ -113,17 +105,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Blank Page");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 204");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Field Picklist");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 204",
+			fieldLabel = "Field Picklist");
 
 		AssertElementPresent(
 			key_entry = "Entry Test",

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectDisplayPage.testcase
@@ -49,8 +49,8 @@ definition {
 		ContentPages.addPage(pageName = "Blank Page");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 203",
-			fieldLabel = "Custom Field");
+			fieldLabel = "Custom Field",
+			pluralLabelName = "Custom Objects 203");
 
 		AssertElementPresent(
 			key_entry = "We make it possible for people to reach their full potential to serve others.",
@@ -106,8 +106,8 @@ definition {
 		ContentPages.addPage(pageName = "Blank Page");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 204",
-			fieldLabel = "Field Picklist");
+			fieldLabel = "Field Picklist",
+			pluralLabelName = "Custom Objects 204");
 
 		AssertElementPresent(
 			key_entry = "Entry Test",

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectCollectionDisplay.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectCollectionDisplay.testcase
@@ -117,19 +117,17 @@ definition {
 			contentType = "Custom Object 300",
 			pageTemplateName = "Blank Display Page");
 
-		PageEditor.addFragment(
-			collectionName = "Content Display",
-			fragmentName = "Collection Display");
-
-		VisualizeObjectCollectionDisplay.addFieldForCollectionDisplay(fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Number");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 300",
+			fieldLabel = "Number");
 
 		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Number");
 
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Text");
+		VisualizeObjectCollectionDisplay.openHeading();
+
+		Select(
+			locator1 = "VisualizeObjectCollectionDisplay#MAP_FRAGMENT",
+			value1 = "Text");
 
 		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Text");
 	}
@@ -195,23 +193,9 @@ definition {
 			contentType = "Custom Object 302",
 			pageTemplateName = "Blank Display Page");
 
-		PageEditor.addFragment(
-			collectionName = "Content Display",
-			fragmentName = "Collection Display");
-
-		PageEditor.editCollectionDisplay(
-			fragmentName = "Collection Display",
-			infoListProviderName = "Custom Objects 302");
-
-		PageEditor.gotoTab(tabName = "Fragments and Widgets");
-
-		VisualizeObjectCollectionDisplay.addFieldForCollectionDisplay(fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.addFieldInsideCollectionDisplay();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Text");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 302",
+			fieldLabel = "Text");
 
 		PageEditor.publish();
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectCollectionDisplay.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectCollectionDisplay.testcase
@@ -118,8 +118,8 @@ definition {
 			pageTemplateName = "Blank Display Page");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 300",
-			fieldLabel = "Number");
+			fieldLabel = "Number",
+			pluralLabelName = "Custom Objects 300");
 
 		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Number");
 
@@ -194,8 +194,8 @@ definition {
 			pageTemplateName = "Blank Display Page");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 302",
-			fieldLabel = "Text");
+			fieldLabel = "Text",
+			pluralLabelName = "Custom Objects 302");
 
 		PageEditor.publish();
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -334,17 +334,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 318");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "BigDecimal");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 318",
+			fieldLabel = "BigDecimal");
 
 		AssertElementPresent(
 			key_entry = "123.123456",
@@ -386,17 +378,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 319");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Boolean");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 319",
+			fieldLabel = "Boolean");
 
 		AssertElementPresent(
 			key_entry = "true",
@@ -438,17 +422,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 320");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Date");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 320",
+			fieldLabel = "Date");
 
 		AssertElementPresent(
 			key_entry = "Jan 1, 2021",
@@ -490,17 +466,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 321");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Double");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 321",
+			fieldLabel = "Double");
 
 		AssertElementPresent(
 			key_entry = "1.54",
@@ -542,17 +510,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 322");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Integer");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 322",
+			fieldLabel = "Integer");
 
 		AssertElementPresent(
 			key_entry = 123456789,
@@ -594,17 +554,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 323");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Long");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 323",
+			fieldLabel = "Long");
 
 		AssertElementPresent(
 			key_entry = 1234567891234567,
@@ -644,19 +596,9 @@ definition {
 			objectName = "CustomObject324",
 			value = "Test text");
 
-		ContentPages.addPage(pageName = "Test Content Page Name");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 324");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "String");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 324",
+			fieldLabel = "String");
 
 		AssertElementPresent(
 			key_entry = "Test text",
@@ -754,13 +696,9 @@ definition {
 			displayPageName = "Blank Display Page",
 			subtype = "Custom Object 326");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Field");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 326",
+			fieldLabel = "Field");
 
 		PageEditor.selectItemToPreviewWithObject(entryValue = "Test Entry");
 
@@ -796,13 +734,9 @@ definition {
 			contentType = "Custom Object 327",
 			pageTemplateName = "Blank Display Page");
 
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Custom Field");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 327",
+			fieldLabel = "Custom Field");
 
 		PageEditor.publish();
 
@@ -810,24 +744,9 @@ definition {
 
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
-		PageEditor.addFragment(
-			collectionName = "Content Display",
-			fragmentName = "Collection Display");
-
-		PageEditor.editCollectionDisplay(
-			fragmentName = "Collection Display",
-			infoListProviderName = "Custom Objects 327");
-
-		Refresh();
-
-		PageEditor.addFragmentToCollectionDisplay(
-			collectionName = "Basic Components",
-			entryTitle = "",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Custom Field");
+		VisualizeObjectCollectionDisplay.mapFragment(
+			pluralLabelName = "Custom Objects 327",
+			fieldLabel = "Custom Field");
 
 		Navigator.gotoNavTab(navTab = "Link");
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -591,10 +591,14 @@ definition {
 
 		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject324");
 
+		
+
 		ObjectAdmin.addObjectSingleFieldEntryViaAPI(
 			fieldName = "customObjectField",
 			objectName = "CustomObject324",
 			value = "Test text");
+
+		ContentPages.addPage(pageName = "Test Content Page Name");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
 			fieldLabel = "String",

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -335,8 +335,8 @@ definition {
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 318",
-			fieldLabel = "BigDecimal");
+			fieldLabel = "BigDecimal",
+			pluralLabelName = "Custom Objects 318");
 
 		AssertElementPresent(
 			key_entry = "123.123456",
@@ -379,8 +379,8 @@ definition {
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 319",
-			fieldLabel = "Boolean");
+			fieldLabel = "Boolean",
+			pluralLabelName = "Custom Objects 319");
 
 		AssertElementPresent(
 			key_entry = "true",
@@ -423,8 +423,8 @@ definition {
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 320",
-			fieldLabel = "Date");
+			fieldLabel = "Date",
+			pluralLabelName = "Custom Objects 320");
 
 		AssertElementPresent(
 			key_entry = "Jan 1, 2021",
@@ -467,8 +467,8 @@ definition {
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 321",
-			fieldLabel = "Double");
+			fieldLabel = "Double",
+			pluralLabelName = "Custom Objects 321");
 
 		AssertElementPresent(
 			key_entry = "1.54",
@@ -511,8 +511,8 @@ definition {
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 322",
-			fieldLabel = "Integer");
+			fieldLabel = "Integer",
+			pluralLabelName = "Custom Objects 322");
 
 		AssertElementPresent(
 			key_entry = 123456789,
@@ -555,8 +555,8 @@ definition {
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 323",
-			fieldLabel = "Long");
+			fieldLabel = "Long",
+			pluralLabelName = "Custom Objects 323");
 
 		AssertElementPresent(
 			key_entry = 1234567891234567,
@@ -597,8 +597,8 @@ definition {
 			value = "Test text");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 324",
-			fieldLabel = "String");
+			fieldLabel = "String",
+			pluralLabelName = "Custom Objects 324");
 
 		AssertElementPresent(
 			key_entry = "Test text",
@@ -697,8 +697,8 @@ definition {
 			subtype = "Custom Object 326");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 326",
-			fieldLabel = "Field");
+			fieldLabel = "Field",
+			pluralLabelName = "Custom Objects 326");
 
 		PageEditor.selectItemToPreviewWithObject(entryValue = "Test Entry");
 
@@ -735,8 +735,8 @@ definition {
 			pageTemplateName = "Blank Display Page");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 327",
-			fieldLabel = "Custom Field");
+			fieldLabel = "Custom Field",
+			pluralLabelName = "Custom Objects 327");
 
 		PageEditor.publish();
 
@@ -745,8 +745,8 @@ definition {
 		ContentPages.addPage(pageName = "Test Content Page Name");
 
 		VisualizeObjectCollectionDisplay.mapFragment(
-			pluralLabelName = "Custom Objects 327",
-			fieldLabel = "Custom Field");
+			fieldLabel = "Custom Field",
+			pluralLabelName = "Custom Objects 327");
 
 		Navigator.gotoNavTab(navTab = "Link");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-194280

Testray subtask: https://testray.liferay.com/home/-/testray/subtasks/2411064957

Some tests that use the `mapFragment` macro are breaking because they are not able to map a field in the heading fragment. The test fails because it tries to edit a non-editable element, and that's because the heading must be inside a collection display, and they aren't. I'm adding the collection display and heading inside the collection display to all tests that use `mapFragment` macro.