### PR TITLE
Test Fix and Improvement test | LPS-194538, LPS-199448

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -537,17 +537,25 @@ definition {
 				filterValue = 10);
 		}
 
-		task ("When the user adds an entry in aggregation fields") {
-
+		task ("When the user go to the object page") {
 			ObjectAdmin.goToCustomObject(objectName = "CustomObjectB");
 
 			LexiconEntry.gotoAdd();
 
 			PortletEntry.save();
 
-		}
-		task ("and When the user adds an entry in the relationship field") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObjectB");
 
+		}
+
+		task ("Then the user is able to add an entry in aggregation field") {
+			AssertElementPresent(
+				key_entry = 0,
+				locator1 = "ObjectPortlet#ENTRY_VALUE");
+
+		}
+
+		task ("and When the user adds an entry in the relationship field") {
 			for (var entryValue : list "0,10") {
 				ObjectAdmin.goToCustomObject(objectName = "CustomObjectA");
 
@@ -562,11 +570,10 @@ definition {
 		}
 
 		task ("Then the sum is done in the aggregation field") {
-
 			ObjectAdmin.goToCustomObject(objectName = "CustomObjectA");
 
 			AssertElementPresent(
-				key_entry = "20",
+				key_entry = 20,
 				locator1 = "ObjectPortlet#ENTRY_VALUE");
 		}
 	}
@@ -4346,6 +4353,7 @@ definition {
 	}
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the integer fields to select data from the object"
 	@priority = 4
 	test IsEqualToIsAvailableForIntegerFields {
@@ -4409,6 +4417,8 @@ definition {
 =======
 >>>>>>> ab669da (LPS-194538 Remove the IsEqualToIsAvailableForIntegerFields since the case is being covered by CanCreateEntryWithAggregationField)
 
+=======
+>>>>>>> 9c791af (LPS-194538 Add task to add entries to ensure the aggregation field is working)
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the long integer fields to select data from the object"
 	@priority = 4
 	test IsNotEqualToIsAvailableForLongIntegerFields {
@@ -4437,9 +4447,11 @@ definition {
 				relationshipLabel = "Relationship",
 				relationshipName = "relationship",
 				relationshipType = "oneToMany");
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObjectA");
 		}
 
-		task ("and Given the aggregation field") {
+		task ("and Given an aggregation field") {
 			ObjectAdmin.openObjectAdmin();
 
 			ObjectPortlet.selectCustomObject(label = "Custom Object B");
@@ -4450,23 +4462,63 @@ definition {
 				field = "Custom Long Integer Field",
 				fieldLabel = "Custom Aggregation",
 				fieldType = "Aggregation",
+<<<<<<< HEAD
 				functionType = "Max",
+=======
+				function = "Sum",
+>>>>>>> 9c791af (LPS-194538 Add task to add entries to ensure the aggregation field is working)
 				relationship = "Relationship");
+
+			ObjectAdmin.goToDetailsTab();
+
+			CreateObject.selectTitleField(fieldLabel = "Custom Aggregation");
+
+			CreateObject.saveObject();
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObjectB");
 		}
 
-		task ("When a new filter is created with the custom long integer field with Is Not Equal To selected") {
+		task ("and Given the filter operator (is equal to) for the long integer field data") {
+			ObjectAdmin.goToFieldsTab();
+
 			ObjectAdmin.goToFieldsDetails(label = "Custom Aggregation");
 
 			ObjectCustomViews.addNewAggregationFilterViaUI(
 				filterBy = "Custom Long Integer Field",
 				filterType = "Is Not Equal To",
-				filterValue = 1);
+				filterValue = 1000);
+
+			ObjectField.save();
 		}
 
-		task ("Then the new filter is created") {
-			ObjectCustomViews.assertPresentEntriesOnFilters(
-				filterBy = "Custom Long Integer Field",
-				filterValue = 1);
+		task ("When the user adds an entry in aggregation fields") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObjectB");
+
+			LexiconEntry.gotoAdd();
+
+			PortletEntry.save();
+		}
+
+		task ("and When the user adds an entry in the relationship field") {
+			for (var entryValue : list "0,500") {
+				ObjectAdmin.goToCustomObject(objectName = "CustomObjectA");
+
+				ObjectPortlet.addSingleFieldEntryViaUI(
+					customField = "Custom Integer Field",
+					entry = 500);
+
+				ObjectPortlet.chooseEntryOnRelationshipField(entryOption = ${entryValue});
+
+				PortletEntry.save();
+			}
+		}
+
+		task ("Then the sum is done in the aggregation field") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObjectA");
+
+			AssertElementPresent(
+				key_entry = 1000,
+				locator1 = "ObjectPortlet#ENTRY_VALUE");
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -4406,6 +4406,8 @@ definition {
 		}
 	}
 
+
+
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the long integer fields to select data from the object"
 	@priority = 4
 	test IsNotEqualToIsAvailableForLongIntegerFields {

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -470,43 +470,104 @@ definition {
 	test CanCreateEntryWithAggregationField {
 		property portal.acceptance = "true";
 
-		task ("Create Custom Object and Custom Relationship itself (via API)") {
+		task ("Given two object definitions related") {
 			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object 161890",
-				objectName = "CustomObject161890",
-				pluralLabelName = "Custom Objects 161890");
+				labelName = "Custom Object A",
+				objectName = "CustomObjectA",
+				pluralLabelName = "Custom Objects A");
+
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object B",
+				objectName = "CustomObjectB",
+				pluralLabelName = "Custom Objects B");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Integer",
+				fieldLabelName = "Custom Integer Field",
+				fieldName = "customIntegerField",
+				fieldType = "Integer",
+				isRequired = "false",
+				objectName = "CustomObjectA");
 
 			ObjectAdmin.addObjectRelationshipViaAPI(
-				objectName_1 = "CustomObject161890",
-				objectName_2 = "CustomObject161890",
+				objectName_1 = "CustomObjectB",
+				objectName_2 = "CustomObjectA",
 				relationshipLabel = "Relationship",
 				relationshipName = "relationship",
 				relationshipType = "oneToMany");
 
-			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject161890");
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObjectA");
 		}
 
-		task ("Go to Custom Object > Fields tab and add Custom Aggregation Field (via UI)") {
+		task ("and Given an aggregation field") {
 			ObjectAdmin.openObjectAdmin();
 
-			ObjectPortlet.selectCustomObject(label = "Custom Object 161890");
+			ObjectPortlet.selectCustomObject(label = "Custom Object B");
 
 			ObjectAdmin.goToFieldsTab();
 
 			ObjectAdmin.addObjectFieldViaUI(
-				field = "ID",
+				field = "Custom Integer Field",
 				fieldLabel = "Custom Aggregation",
 				fieldType = "Aggregation",
-				functionType = "Max",
+				function = "Sum",
 				relationship = "Relationship");
+
+			ObjectAdmin.goToDetailsTab();
+
+			CreateObject.selectTitleField(fieldLabel = "Custom Aggregation");
+
+			CreateObject.saveObject();
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObjectB");
 		}
 
-		task ("Assert that there is Custom Aggregation Field") {
-			Refresh();
+		task ("and Given the filter operator (is equal to) for the integer field data") {
+			ObjectAdmin.goToFieldsTab();
 
-			ObjectAdmin.assertObjectField(
-				fieldLabel = "Custom Aggregation",
-				fieldType = "Aggregation");
+			ObjectAdmin.goToFieldsDetails(label = "Custom Aggregation");
+
+			ObjectCustomViews.addNewAggregationFilterViaUI(
+				filterBy = "Custom Integer Field",
+				filterType = "Is Equal To",
+				filterValue = 10);
+
+			ObjectCustomViews.assertPresentEntriesOnFilters(
+				filterBy = "Custom Integer Field",
+				filterValue = 10);
+		}
+
+		task ("When the user adds an entry in aggregation fields") {
+
+			ObjectAdmin.goToCustomObject(objectName = "CustomObjectB");
+
+			LexiconEntry.gotoAdd();
+
+			PortletEntry.save();
+
+		}
+		task ("and When the user adds an entry in the relationship field") {
+
+			for (var entryValue : list "0,10") {
+				ObjectAdmin.goToCustomObject(objectName = "CustomObjectA");
+
+				ObjectPortlet.addSingleFieldEntryViaUI(
+					customField = "Custom Integer Field",
+					entry = 10);
+
+				ObjectPortlet.chooseEntryOnRelationshipField(entryOption = "${entryValue}");
+
+				PortletEntry.save();
+			}
+		}
+
+		task ("Then the sum is done in the aggregation field") {
+
+			ObjectAdmin.goToCustomObject(objectName = "CustomObjectA");
+
+			AssertElementPresent(
+				key_entry = "20",
+				locator1 = "ObjectPortlet#ENTRY_VALUE");
 		}
 	}
 
@@ -4287,32 +4348,42 @@ definition {
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the integer fields to select data from the object"
 	@priority = 4
 	test IsEqualToIsAvailableForIntegerFields {
-		task ("Given a custom object with an integer field type") {
+		task ("Given two object definitions with an integer field and a relationship") {
 			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object",
-				objectName = "CustomObject",
-				pluralLabelName = "Custom Objects");
+				labelName = "Custom Object A",
+				objectName = "CustomObjectA",
+				pluralLabelName = "Custom Objects A");
+
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object B",
+				objectName = "CustomObjectB",
+				pluralLabelName = "Custom Objects B");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Integer",
+				fieldLabelName = "Custom Integer Field",
+				fieldName = "customIntegerField",
+				fieldType = "Integer",
+				isRequired = "false",
+				objectName = "CustomObjectA");
 
 			ObjectAdmin.addObjectRelationshipViaAPI(
-				objectName_1 = "CustomObject",
-				objectName_2 = "CustomObject",
+				objectName_1 = "CustomObjectB",
+				objectName_2 = "CustomObjectA",
 				relationshipLabel = "Relationship",
 				relationshipName = "relationship",
 				relationshipType = "oneToMany");
+		}
 
+		task ("and Given an aggregation field") {
 			ObjectAdmin.openObjectAdmin();
 
-			ObjectPortlet.selectCustomObject(label = "Custom Object");
+			ObjectPortlet.selectCustomObject(label = "Custom Object B");
 
 			ObjectAdmin.goToFieldsTab();
 
 			ObjectAdmin.addObjectFieldViaUI(
-				fieldLabel = "Custom Integer",
-				fieldName = "customInteger",
-				fieldType = "Integer");
-
-			ObjectAdmin.addObjectFieldViaUI(
-				field = "Custom Integer",
+				field = "Custom Integer Field",
 				fieldLabel = "Custom Aggregation",
 				fieldType = "Aggregation",
 				functionType = "Max",
@@ -4323,65 +4394,14 @@ definition {
 			ObjectAdmin.goToFieldsDetails(label = "Custom Aggregation");
 
 			ObjectCustomViews.addNewAggregationFilterViaUI(
-				filterBy = "Custom Integer",
+				filterBy = "Custom Integer Field",
 				filterType = "Is Equal To",
 				filterValue = 1);
 		}
 
 		task ("Then the new filter is created") {
 			ObjectCustomViews.assertPresentEntriesOnFilters(
-				filterBy = "Custom Integer",
-				filterValue = 1);
-		}
-	}
-
-	@description = "Verify that the Is Equals to operator is available when adding filters for the long integer fields to select data from the object"
-	@priority = 4
-	test IsEqualToIsAvailableForLongIntegerFields {
-		task ("Given a custom object with a long integer field type") {
-			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object",
-				objectName = "CustomObject",
-				pluralLabelName = "Custom Objects");
-
-			ObjectAdmin.addObjectRelationshipViaAPI(
-				objectName_1 = "CustomObject",
-				objectName_2 = "CustomObject",
-				relationshipLabel = "Relationship",
-				relationshipName = "relationship",
-				relationshipType = "oneToMany");
-
-			ObjectAdmin.openObjectAdmin();
-
-			ObjectPortlet.selectCustomObject(label = "Custom Object");
-
-			ObjectAdmin.goToFieldsTab();
-
-			ObjectAdmin.addObjectFieldViaUI(
-				fieldLabel = "Custom Long Integer",
-				fieldName = "customLongInteger",
-				fieldType = "Long Integer");
-
-			ObjectAdmin.addObjectFieldViaUI(
-				field = "Custom Long Integer",
-				fieldLabel = "Custom Aggregation",
-				fieldType = "Aggregation",
-				functionType = "Max",
-				relationship = "Relationship");
-		}
-
-		task ("When a new filter is created with the custom long integer field with Is Equal To selected") {
-			ObjectAdmin.goToFieldsDetails(label = "Custom Aggregation");
-
-			ObjectCustomViews.addNewAggregationFilterViaUI(
-				filterBy = "Custom Long Integer",
-				filterType = "Is Equal To",
-				filterValue = 1);
-		}
-
-		task ("Then the new filter is created") {
-			ObjectCustomViews.assertPresentEntriesOnFilters(
-				filterBy = "Custom Long Integer",
+				filterBy = "Custom Integer Field",
 				filterValue = 1);
 		}
 	}
@@ -4389,32 +4409,42 @@ definition {
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the long integer fields to select data from the object"
 	@priority = 4
 	test IsNotEqualToIsAvailableForLongIntegerFields {
-		task ("Given a custom object with a long integer field type") {
+		task ("Given two object definitions with a long integer field and a relationship") {
 			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object",
-				objectName = "CustomObject",
-				pluralLabelName = "Custom Objects");
+				labelName = "Custom Object A",
+				objectName = "CustomObjectA",
+				pluralLabelName = "Custom Objects A");
+
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object B",
+				objectName = "CustomObjectB",
+				pluralLabelName = "Custom Objects B");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "LongInteger",
+				fieldLabelName = "Custom Long Integer Field",
+				fieldName = "customLongIntegerField",
+				fieldType = "Long",
+				isRequired = "false",
+				objectName = "CustomObjectA");
 
 			ObjectAdmin.addObjectRelationshipViaAPI(
-				objectName_1 = "CustomObject",
-				objectName_2 = "CustomObject",
+				objectName_1 = "CustomObjectB",
+				objectName_2 = "CustomObjectA",
 				relationshipLabel = "Relationship",
 				relationshipName = "relationship",
 				relationshipType = "oneToMany");
+		}
 
+		task ("and Given the aggregation field") {
 			ObjectAdmin.openObjectAdmin();
 
-			ObjectPortlet.selectCustomObject(label = "Custom Object");
+			ObjectPortlet.selectCustomObject(label = "Custom Object B");
 
 			ObjectAdmin.goToFieldsTab();
 
 			ObjectAdmin.addObjectFieldViaUI(
-				fieldLabel = "Custom Long Integer",
-				fieldName = "customLongInteger",
-				fieldType = "Long Integer");
-
-			ObjectAdmin.addObjectFieldViaUI(
-				field = "Custom Long Integer",
+				field = "Custom Long Integer Field",
 				fieldLabel = "Custom Aggregation",
 				fieldType = "Aggregation",
 				functionType = "Max",
@@ -4425,14 +4455,14 @@ definition {
 			ObjectAdmin.goToFieldsDetails(label = "Custom Aggregation");
 
 			ObjectCustomViews.addNewAggregationFilterViaUI(
-				filterBy = "Custom Long Integer",
+				filterBy = "Custom Long Integer Field",
 				filterType = "Is Not Equal To",
 				filterValue = 1);
 		}
 
 		task ("Then the new filter is created") {
 			ObjectCustomViews.assertPresentEntriesOnFilters(
-				filterBy = "Custom Long Integer",
+				filterBy = "Custom Long Integer Field",
 				filterValue = 1);
 		}
 	}
@@ -4528,29 +4558,39 @@ definition {
 	@description = "Verify that the Range - Start/End operator is available when adding filters for the date fields to select date from the object"
 	@priority = 4
 	test RangeIsAvailableForDateFields {
-		task ("Given a custom object with a date field type") {
+		task ("Given two object definitions with a date field and a relationship") {
 			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object",
-				objectName = "CustomObject",
-				pluralLabelName = "Custom Objects");
+				labelName = "Custom Object A",
+				objectName = "CustomObjectA",
+				pluralLabelName = "Custom Objects A");
+
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object B",
+				objectName = "CustomObjectB",
+				pluralLabelName = "Custom Objects B");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Date",
+				fieldLabelName = "Custom Date Field",
+				fieldName = "customDateField",
+				fieldType = "Date",
+				isRequired = "false",
+				objectName = "CustomObjectA");
 
 			ObjectAdmin.addObjectRelationshipViaAPI(
-				objectName_1 = "CustomObject",
-				objectName_2 = "CustomObject",
+				objectName_1 = "CustomObjectB",
+				objectName_2 = "CustomObjectA",
 				relationshipLabel = "Relationship",
 				relationshipName = "relationship",
 				relationshipType = "oneToMany");
+		}
 
+		task ("and Given the aggregation field") {
 			ObjectAdmin.openObjectAdmin();
 
-			ObjectPortlet.selectCustomObject(label = "Custom Object");
+			ObjectPortlet.selectCustomObject(label = "Custom Object B");
 
 			ObjectAdmin.goToFieldsTab();
-
-			ObjectAdmin.addObjectFieldViaUI(
-				fieldLabel = "Custom Date",
-				fieldName = "customDate",
-				fieldType = "Date");
 
 			ObjectAdmin.addObjectFieldViaUI(
 				fieldLabel = "Custom Aggregation",
@@ -4564,13 +4604,13 @@ definition {
 
 			ObjectCustomViews.addNewAggregationFilterViaUI(
 				dateValueList = "01-01-2000, 01-01-2001",
-				filterBy = "Custom Date",
+				filterBy = "Custom Date Field",
 				filterType = "Range");
 		}
 
 		task ("Then the new filter is created") {
 			ObjectCustomViews.assertPresentEntriesOnFilters(
-				filterBy = "Custom Date",
+				filterBy = "Custom Date Field",
 				filterValue = "2000-01-01, 2001-01-01");
 		}
 	}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -470,7 +470,7 @@ definition {
 	test CanCreateEntryWithAggregationField {
 		property portal.acceptance = "true";
 
-		task ("Given two object definitions related") {
+		task ("Given two related object definitions") {
 			ObjectAdmin.addObjectViaAPI(
 				labelName = "Custom Object A",
 				objectName = "CustomObjectA",
@@ -4405,8 +4405,6 @@ definition {
 				filterValue = 1);
 		}
 	}
-
-
 
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the long integer fields to select data from the object"
 	@priority = 4

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -545,14 +545,12 @@ definition {
 			PortletEntry.save();
 
 			ObjectAdmin.goToCustomObject(objectName = "CustomObjectB");
-
 		}
 
 		task ("Then the user is able to add an entry in aggregation field") {
 			AssertElementPresent(
 				key_entry = 0,
 				locator1 = "ObjectPortlet#ENTRY_VALUE");
-
 		}
 
 		task ("and When the user adds an entry in the relationship field") {
@@ -563,7 +561,7 @@ definition {
 					customField = "Custom Integer Field",
 					entry = 10);
 
-				ObjectPortlet.chooseEntryOnRelationshipField(entryOption = "${entryValue}");
+				ObjectPortlet.chooseEntryOnRelationshipField(entryOption = ${entryValue});
 
 				PortletEntry.save();
 			}
@@ -4352,8 +4350,6 @@ definition {
 		}
 	}
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the integer fields to select data from the object"
 	@priority = 4
 	test IsEqualToIsAvailableForIntegerFields {
@@ -4414,11 +4410,7 @@ definition {
 				filterValue = 1);
 		}
 	}
-=======
->>>>>>> ab669da (LPS-194538 Remove the IsEqualToIsAvailableForIntegerFields since the case is being covered by CanCreateEntryWithAggregationField)
 
-=======
->>>>>>> 9c791af (LPS-194538 Add task to add entries to ensure the aggregation field is working)
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the long integer fields to select data from the object"
 	@priority = 4
 	test IsNotEqualToIsAvailableForLongIntegerFields {
@@ -4462,11 +4454,8 @@ definition {
 				field = "Custom Long Integer Field",
 				fieldLabel = "Custom Aggregation",
 				fieldType = "Aggregation",
-<<<<<<< HEAD
-				functionType = "Max",
-=======
 				function = "Sum",
->>>>>>> 9c791af (LPS-194538 Add task to add entries to ensure the aggregation field is working)
+				functionType = "Max",
 				relationship = "Relationship");
 
 			ObjectAdmin.goToDetailsTab();
@@ -4638,6 +4627,8 @@ definition {
 				relationshipLabel = "Relationship",
 				relationshipName = "relationship",
 				relationshipType = "oneToMany");
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObjectA");
 		}
 
 		task ("and Given the aggregation field") {
@@ -4652,21 +4643,63 @@ definition {
 				fieldType = "Aggregation",
 				functionType = "Count",
 				relationship = "Relationship");
+
+			ObjectAdmin.goToDetailsTab();
+
+			CreateObject.selectTitleField(fieldLabel = "Custom Aggregation");
+
+			CreateObject.saveObject();
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObjectB");
 		}
 
-		task ("When a new filter is created with the custom date field with range selected") {
+		task ("and Given a new filter created with the custom date field with range selected") {
+			ObjectAdmin.goToFieldsTab();
+
 			ObjectAdmin.goToFieldsDetails(label = "Custom Aggregation");
 
 			ObjectCustomViews.addNewAggregationFilterViaUI(
 				dateValueList = "01-01-2000, 01-01-2001",
 				filterBy = "Custom Date Field",
 				filterType = "Range");
+
+			ObjectField.save();
 		}
 
-		task ("Then the new filter is created") {
-			ObjectCustomViews.assertPresentEntriesOnFilters(
-				filterBy = "Custom Date Field",
-				filterValue = "2000-01-01, 2001-01-01");
+		task ("When the user adds an entry in aggregation fields") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObjectB");
+
+			LexiconEntry.gotoAdd();
+
+			PortletEntry.save();
+		}
+
+		task ("and When the user adds an entry in the relationship field") {
+			for (var entryValue : list "0,1") {
+				ObjectAdmin.goToCustomObject(objectName = "CustomObjectA");
+
+				LexiconEntry.gotoAdd();
+
+				Type.type(
+					locator1 = "ObjectPortlet#ADD_OBJECT_ENTRY",
+					value1 = "10/01/2000");
+
+				Click(locator1 = "ObjectPortlet#SEARCH_RELATIONSHIP_ENTRY");
+
+				Click(
+					key_dropdownItem = ${entryValue},
+					locator1 = "ObjectPortlet#CHECK_UNCHECK_DROPDOWN_ITEM");
+
+				PortletEntry.save();
+			}
+		}
+
+		task ("Then the count is done in the aggregation field") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObjectA");
+
+			AssertElementPresent(
+				key_entry = 2,
+				locator1 = "ObjectPortlet#ENTRY_VALUE");
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -510,12 +510,14 @@ definition {
 				field = "Custom Integer Field",
 				fieldLabel = "Custom Aggregation",
 				fieldType = "Aggregation",
-				function = "Sum",
+				functionType = "Sum",
 				relationship = "Relationship");
 
 			ObjectAdmin.goToDetailsTab();
 
-			CreateObject.selectTitleField(fieldLabel = "Custom Aggregation");
+			CreateObject.selectTitleField(
+				currentOption = "ID",
+				fieldLabel = "Custom Aggregation");
 
 			CreateObject.saveObject();
 
@@ -4454,13 +4456,14 @@ definition {
 				field = "Custom Long Integer Field",
 				fieldLabel = "Custom Aggregation",
 				fieldType = "Aggregation",
-				function = "Sum",
-				functionType = "Max",
+				functionType = "Sum",
 				relationship = "Relationship");
 
 			ObjectAdmin.goToDetailsTab();
 
-			CreateObject.selectTitleField(fieldLabel = "Custom Aggregation");
+			CreateObject.selectTitleField(
+				currentOption = "ID",
+				fieldLabel = "Custom Aggregation");
 
 			CreateObject.saveObject();
 
@@ -4646,7 +4649,9 @@ definition {
 
 			ObjectAdmin.goToDetailsTab();
 
-			CreateObject.selectTitleField(fieldLabel = "Custom Aggregation");
+			CreateObject.selectTitleField(
+				currentOption = "ID",
+				fieldLabel = "Custom Aggregation");
 
 			CreateObject.saveObject();
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -4345,6 +4345,7 @@ definition {
 		}
 	}
 
+<<<<<<< HEAD
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the integer fields to select data from the object"
 	@priority = 4
 	test IsEqualToIsAvailableForIntegerFields {
@@ -4405,6 +4406,8 @@ definition {
 				filterValue = 1);
 		}
 	}
+=======
+>>>>>>> ab669da (LPS-194538 Remove the IsEqualToIsAvailableForIntegerFields since the case is being covered by CanCreateEntryWithAggregationField)
 
 	@description = "Verify that the Is Not Equals to operator is available when adding filters for the long integer fields to select data from the object"
 	@priority = 4


### PR DESCRIPTION
Context

Tickets related
https://liferay.atlassian.net/browse/LPS-194538
https://liferay.atlassian.net/browse/LPS-199448

So basically [this](https://github.com/liferay-objects/liferay-portal/pull/2413/commits/0b823feac3a6d0f7078ab23c4a2ff44ee3610674) PR makes changes to the filter section of the aggregation fields. With that, we need to change the relationship to no longer be a relationship with itself.

After investigating more about the coverage of the aggregation field feature, I noticed that we have this test: `CanCreateEntryWithAggregationField` And that the flow of adding entries to make sure that the aggregation works is missing. I believe it makes more sense to add the entry addition step to it as well.

I have three other points about the tests I fixed:

1 - These tests are without story LPS. I think I can add the LPS from the Aggregation story since it uses the aggregation field.

2 - The goals for these tests, following the logic and description, would just be to assert that the operators used when creating the field filter are available. Adding the entry addition step also makes sense to make sure the operators work.

3 - The following tests were automated:
IsEqualToIsAvailableForIntegerFields
IsEqualToIsAvailableForLongIntegerFields
IsNotEqualToIsAvailableForLongIntegerFields
RangeIsAvailableForDateFields.

I don't think it makes sense to have two tests that test the same operator, in this case, "Is Equal To" just by varying the field. I think the ideal would be to exclude both of these and have only 3 testing the available operators: "Is Equal To", "Is Not Equal To" and "Range". They are the possible operators that we can use with the aggregation field.

Then, I made improvements on the following tests:

RangeIsAvailableForDateFields
IsNotEqualToIsAvailableForLongIntegerFields
CanCreateEntryWithAggregationField

And I deleted:
IsEqualToIsAvailableForIntegerFields
IsEqualToIsAvailableForLongIntegerFields