### PR TITLE
LPS-202741 | Test Fix | Master

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1478,21 +1478,6 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro moveDefinitionFolder(definitionName = null,folderLabel = null) {
-		Click(
-			key_value = ${definitionName},
-			locator1 = "ObjectAdmin#BODY_VERTICAL_ELLIPSIS");
-
-		DropdownMenuItem.click(menuItem = "Move");
-
-		Click(
-			key_folderLabel = ${folderLabel},
-			locator1 = "ObjectAdmin#SELECT_MOVE_FOLDER");
-
-		Button.click(button = "Move");
-	}
-
-	@summary = "Default summary"
 	macro openMySubmissions() {
 		Navigator.openURL();
 

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
@@ -647,7 +647,7 @@
 	</tr>
 	<tr>
 		<td>GO_TO_FOLDER</td>
-		<td>//div[contains(@class, 'autofit-col-expand') and contains(., 'key_folderName')]//*[contains(@title, 'Go to Folder')]</td>
+		<td>//div[contains(@class, 'autofit-col-expand') and contains(., '${key_folderLabel}')]//*[contains(@title, 'Go to Folder')]</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
@@ -641,11 +641,6 @@
 		<td></td>
 	</tr>
 	<tr>
-		<td>SELECT_MOVE_FOLDER</td>
-		<td>//span[contains(@class,'move-object-definition-list-item-label') and contains(text(),'${key_folderLabel}')]</td>
-		<td></td>
-	</tr>
-	<tr>
 		<td>GO_TO_FOLDER</td>
 		<td>//div[contains(@class, 'autofit-col-expand') and contains(., '${key_folderLabel}')]//*[contains(@title, 'Go to Folder')]</td>
 		<td></td>

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectModelBuilder.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectModelBuilder.path
@@ -42,7 +42,7 @@
 	</tr>
 	<tr>
 		<td>SELECT_OBJECT_IN_LEFT_SIDEBAR</td>
-		<td>//div[contains(@class,'left-sidebar-current-object-folder-group')]//span[contains(@class,'c-inner') and contains(.,'${key_label}')]</td>
+		<td>//div[@id = '${key_folderLabel}']//span[contains(@class,'c-inner') and contains(.,'${key_objectLabel}')]</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectModelBuilder.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectModelBuilder.path
@@ -45,6 +45,11 @@
 		<td>//div[contains(@class,'left-sidebar-current-object-folder-group')]//span[contains(@class,'c-inner') and contains(.,'${key_label}')]</td>
 		<td></td>
 	</tr>
+	<tr>
+		<td>OBJECT_IN_LEFT_SIDEBAR_KEBAB_MENU</td>
+		<td>//span[normalize-space()='${key_objectLabel}']//following-sibling::div//button[contains(@class,'dropdown-toggle')]</td>
+		<td></td>
+	</tr>
 </tbody>
 </table>
 </body>

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFolder.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFolder.testcase
@@ -29,7 +29,7 @@ definition {
 		property custom.properties = "feature.flag.LPS-148856=true";
 
 		task ("Given two object folders titled Folder A and Folder B") {
-			JSONObjectFolder.addFolder(
+			var folderERC = JSONObjectFolder.addFolder(
 				folderLabel = "Folder A",
 				folderName = "FolderA");
 
@@ -40,42 +40,37 @@ definition {
 
 		task ("and Given an object definition in Folder A") {
 			ObjectAdmin.addObjectViaAPI(
-				folderName = "FolderA",
 				labelName = "Custom Object 185681",
 				objectName = "CustomObject185681",
 				pluralLabelName = "Custom Objects 185681");
+
+			JSONObject.updateObject(
+				configKey = "objectFolderExternalReferenceCode",
+				configValue = ${folderERC},
+				objectName = "CustomObject185681");
 		}
 
 		task ("When the user navigates to Folder B and moves the object definition to the current folder") {
-			ObjectAdmin.openObjectAdmin();
-
-			Click.javaScriptClick(
-				folderLabel = "Folder A",
-				locator1 = "ObjectAdmin#SIDEBAR_ITEM");
-
 			ObjectModelBuilder.openObjectFolderInModelBuilder(objectFolderName = "FolderA");
 
-			Click(
-				key_folderName = "Folder B",
+			Click.javaScriptClick(
+				key_folderLabel = "Folder B",
 				locator1 = "ObjectAdmin#GO_TO_FOLDER");
 
-			Click(
-				locator1 = "Treeview#NODE_COLLAPSED",
-				value1 = "Folder A");
+			Click.javaScriptClick(
+				key_objectLabel = "Custom Object 185681",
+				locator1 = "ObjectModelBuilder#OBJECT_IN_LEFT_SIDEBAR_KEBAB_MENU");
 
-			ObjectAdmin.moveDefinitionFolder(
-				definitionName = "Custom Object 185681",
-				folderLabel = "Folder B");
+			Click(
+				key_item = "Move to Current Folder",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
 		}
 
 		task ("Then the object definition is moved from Folder A to the current folder, Folder B") {
-			Click.javaScriptClick(
-				folderLabel = "Folder B",
-				locator1 = "ObjectAdmin#SIDEBAR_ITEM");
-
 			AssertElementPresent(
-				key_label = "Custom Object 185681",
-				locator1 = "ObjectPortlet#SELECT_CUSTOM_OBJECT");
+				key_folderLabel = "Folder B",
+				key_objectLabel = "Custom Object 185681",
+				locator1 = "ObjectModelBuilder#SELECT_OBJECT_IN_LEFT_SIDEBAR");
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectModelBuilder.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectModelBuilder.testcase
@@ -146,11 +146,13 @@ definition {
 		task ("Then only Account is seen") {
 			for (var objectLabel : list "Postal Address,Commerce Product,Organization,User,Commerce Order,Commerce Product") {
 				AssertElementNotPresent(
-					key_label = ${objectLabel},
+					key_folderLabel = "Uncategorized",
+					key_objectLabel = ${objectLabel},
 					locator1 = "ObjectModelBuilder#SELECT_OBJECT_IN_LEFT_SIDEBAR");
 
 				AssertElementPresent(
-					key_label = "Account",
+					key_folderLabel = "Uncategorized",
+					key_objectLabel = "Account",
 					locator1 = "ObjectModelBuilder#SELECT_OBJECT_IN_LEFT_SIDEBAR");
 			}
 		}


### PR DESCRIPTION
[LPS-202741](https://liferay.atlassian.net/browse/LPS-202741)

Changes:
- variable in the GO_TO_FOLDER path is fixed
- path OBJECT_IN_LEFT_SIDEBAR_KEBAB_MENU is created for the Poshi can use the kebab menu to move the object to the current folder
- the test `CanMoveObjectDefinitionToCurrentFolder` is fixed so that the steps are carried out correctly in the model builder (the previous steps were confusing because they were based on page view elements) and unnecessary steps were removed
- the path SELECT_OBJECT_IN_LEFT_SIDEBAR is updated to use the folder label and the change is applied to test `CanSearchForObjectDefinition` (the test passes)

This is the original ticket for automation: [LPS-195650](https://liferay.atlassian.net/browse/LPS-195650)