### PR TITLE
LPS-202410 | Test fix |  Master

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectForms.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectForms.testcase
@@ -136,6 +136,8 @@ definition {
 	@description = "LPS-143064 - Verify that, when using objects as storage type, the user must be able to map to this field type to Rich Text Field and view its entries"
 	@priority = 4
 	test CanMapAndViewEntriesForRichTextField {
+		property test.liferay.virtual.instance = "false";
+
 		ObjectAdmin.addObjectViaAPI(
 			labelName = "Custom Object 151597",
 			objectName = "CustomObject151597",
@@ -382,6 +384,8 @@ definition {
 	@description = "LPS-135429 - It is possible to retrieve objects data from Data Providers and use in a Select from List field in Forms"
 	@priority = 4
 	test CanRetrieveDataProvidersOnSelectFromListField {
+		property test.liferay.virtual.instance = "false";
+
 		ObjectAdmin.addObjectViaAPI(
 			labelName = "Custom Object 213",
 			objectName = "CustomObject213",
@@ -451,6 +455,8 @@ definition {
 	@description = "LPS-135429 - It is possible to retrieve objects data from Data Providers and use in a Text field in Form"
 	@priority = 4
 	test CanRetrieveDataProvidersOnTextField {
+		property test.liferay.virtual.instance = "false";
+
 		ObjectAdmin.addObjectViaAPI(
 			labelName = "Custom Object 214",
 			objectName = "CustomObject214",


### PR DESCRIPTION
## Add virtual instance = false and run test type on data provider tests

- Ticket for this PR: [LPS-202410](https://liferay.atlassian.net/browse/LPS-202410)

### Problem root cause:
These tests using data provider were failing on our routine because:
- To create a data provider, you can't use a URL of a local connection.
- Taking a look at the code of the test, looks that the property to run the test on a virtual instance was removed.
- Once the property were removed, the tests start to fail because the tests start to use a URL to create a data provider and local connections are not allowed when doing that.

### Proposed solution:
Running this tests with the virtual instance property on my [remote](https://github.com/mateussandes23/liferay-portal/pull/11), looks they passed at the end of routine so, because of that, I resolved to adopt this approach on the fix of those tests.