### PR TITLE
LPS-201126 | Test fix | Master

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -4625,8 +4625,8 @@ definition {
 
 		ObjectAdmin.addObjectFieldViaAPI(
 			fieldBusinessType = "Date",
-			fieldLabelName = "Date",
-			fieldName = "customObjectField",
+			fieldLabelName = "Event",
+			fieldName = "event",
 			fieldType = "Date",
 			isRequired = "false",
 			objectName = "CustomObject113");
@@ -4644,14 +4644,13 @@ definition {
 
 		ObjectPortlet.selectCustomObject(label = "Custom Object 113");
 
-		CreateObject.selectTitleField(fieldLabel = "Date");
+		CreateObject.selectTitleField(fieldLabel = "Event");
 
 		CreateObject.saveObject();
 
-		ObjectAdmin.addObjectSingleFieldEntryViaAPI(
-			fieldName = "customObjectField",
-			objectName = "CustomObject113",
-			value = "2021-01-01");
+		ObjectAdmin.goToCustomObject(objectName = "CustomObject113");
+
+		ObjectPortlet.addSingleFieldEntryViaUI(entry = "01-01-2021");
 
 		ObjectAdmin.goToCustomObject(objectName = "CustomObject113");
 


### PR DESCRIPTION
# Test can't select "Date" custom field as title field

**Ticket for this PR:** [LPS-201126
](https://liferay.atlassian.net/browse/LPS-201126)

### Problem root cause:
For this fix, we noticed that:

1. The test was selecting the 'Create Date' as title field. That was happening because the date field has the label "Date" what made the test select this option with "Date" on it

#### Fail snippet:

```
`java.lang.Exception: Element is not present at "//button[contains(@class,'dropdown-item') and contains(text(),'Jan 1, 2021')]"
```

2. Another point was that the entry via API was empty.

### Suggested solution:
1. For the fix, I just updated the date field label to "Event" to turn the label unique, this way the test will not confuse the fields when selecting.

2. Change the way the test add entries to via UI.

**Note:**
Here you can see the [thread](https://liferay.slack.com/archives/C026UR5976G/p1701353343489329) that I opened to ask if the behavior found when working on this test is expected or a bug.